### PR TITLE
Improved Smart Detection behavior

### DIFF
--- a/src/dev/impl/DevToys/Core/Settings/PredefinedSettings.cs
+++ b/src/dev/impl/DevToys/Core/Settings/PredefinedSettings.cs
@@ -53,6 +53,15 @@ namespace DevToys.Core.Settings
                 isRoaming: true,
                 defaultValue: true);
 
+        /// <summary>
+        /// Whether the application should automatically paste the content of the clipboard when selecting a tool that has been automatically recommended by Smart Detection.
+        /// </summary>
+        public static readonly SettingDefinition<bool> SmartDetectionPaste
+            = new(
+                name: nameof(SmartDetectionPaste),
+                isRoaming: true,
+                defaultValue: true);
+
         public static readonly string[] SupportedFonts
             = new[]
             {

--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -657,6 +657,16 @@ namespace DevToys
         public string SmartDetectionDescription => _resources.GetString("SmartDetectionDescription");
 
         /// <summary>
+        /// Gets the resource SmartDetectionHowTo.
+        /// </summary>
+        public string SmartDetectionHowTo => _resources.GetString("SmartDetectionHowTo");
+
+        /// <summary>
+        /// Gets the resource SmartDetectionPaste.
+        /// </summary>
+        public string SmartDetectionPaste => _resources.GetString("SmartDetectionPaste");
+
+        /// <summary>
         /// Gets the resource SourceCode.
         /// </summary>
         public string SourceCode => _resources.GetString("SourceCode");

--- a/src/dev/impl/DevToys/Strings/en/Settings.resw
+++ b/src/dev/impl/DevToys/Strings/en/Settings.resw
@@ -195,6 +195,12 @@
   <data name="SmartDetectionDescription" xml:space="preserve">
     <value>Automatically detect the best tool based on the clipboard content</value>
   </data>
+  <data name="SmartDetectionHowTo" xml:space="preserve">
+    <value>How to use Smart Detection</value>
+  </data>
+  <data name="SmartDetectionPaste" xml:space="preserve">
+    <value>Automatically paste the clipboard content when selecting a recommended tool</value>
+  </data>
   <data name="SourceCode" xml:space="preserve">
     <value>Source code</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/fr/Settings.resw
+++ b/src/dev/impl/DevToys/Strings/fr/Settings.resw
@@ -195,6 +195,12 @@
   <data name="SmartDetectionDescription" xml:space="preserve">
     <value>Détecter automatiquement le meilleur outil en fonction du contenu du presse-papiers</value>
   </data>
+  <data name="SmartDetectionHowTo" xml:space="preserve">
+    <value>Comment utiliser la  Détection intelligente</value>
+  </data>
+  <data name="SmartDetectionPaste" xml:space="preserve">
+    <value>Coller automatiquement le contenu du presse-papier lorsqu'un outil recommandé est sélectionné.</value>
+  </data>
   <data name="SourceCode" xml:space="preserve">
     <value>Code source</value>
   </data>

--- a/src/dev/impl/DevToys/ViewModels/Tools/Settings/SettingsToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Settings/SettingsToolViewModel.cs
@@ -55,6 +55,12 @@ namespace DevToys.ViewModels.Settings
             set => _settingsProvider.SetSetting(PredefinedSettings.SmartDetection, value);
         }
 
+        internal bool SmartDetectionPaste
+        {
+            get => _settingsProvider.GetSetting(PredefinedSettings.SmartDetectionPaste);
+            set => _settingsProvider.SetSetting(PredefinedSettings.SmartDetectionPaste, value);
+        }
+
         internal ObservableCollection<string> SupportedFonts { get; } = new();
 
         internal string TextEditorFont

--- a/src/dev/impl/DevToys/Views/Tools/Settings/SettingsToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Settings/SettingsToolPage.xaml
@@ -64,7 +64,15 @@
             </controls:ExpandableSettingControl.Icon>
             <ToggleSwitch Style="{StaticResource RightAlignedToggleSwitchStyle}" IsOn="{x:Bind ViewModel.SmartDetection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
             <controls:ExpandableSettingControl.ExpandableContent>
-                <Image Source="/Assets/DemoSmartDetection.gif" MinHeight="300"/>
+                <StackPanel Spacing="4" HorizontalAlignment="Stretch">
+                    <CheckBox
+                        IsChecked="{x:Bind ViewModel.SmartDetection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        Content="{x:Bind ViewModel.Strings.SmartDetectionPaste}"
+                        HorizontalAlignment="Stretch"/>
+
+                    <TextBlock Text="{x:Bind ViewModel.Strings.SmartDetectionHowTo}"/>
+                    <Image Source="/Assets/DemoSmartDetection.gif" MinHeight="300"/>
+                </StackPanel>
             </controls:ExpandableSettingControl.ExpandableContent>
         </controls:ExpandableSettingControl>
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

- When using Smart Detection, if 2 tools or more were recommended, the clipboard data would never been paste in the tool.
- When using Smart Detection, users should have the choice to automatically paste data or note.

Issue Number: #20, #21

## What is the new behavior?

- Added a new option to disable the automatic clipboard data insertion
- Changed the Smart Detection behavior so we paste automatically when a recommended tool is selected.

![image](https://user-images.githubusercontent.com/3747805/136877654-dad7ce1e-03c9-4bf7-84cc-ac516623e4b9.png)


## Other information

The clipboard data won't be paste if:
- We selected a non-recommended tool before the recommended one
- The clipboard data has already been paste.
- The clipboard data didn't change since the last time the window had the focus
- The recommended tools are the same than the last time the window had the focus

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass