### PR TITLE
Use any font in DevToys editor

### DIFF
--- a/src/dev/impl/DevToys/App.xaml.cs
+++ b/src/dev/impl/DevToys/App.xaml.cs
@@ -249,11 +249,11 @@ namespace DevToys
 
             if (!systemFonts.Contains(currentFont))
             {
-                for (int i = 0; i < PredefinedSettings.SupportedFonts.Length; i++)
+                for (int i = 0; i < PredefinedSettings.DefaultFonts.Length; i++)
                 {
-                    if (systemFonts.Contains(PredefinedSettings.SupportedFonts[i]))
+                    if (systemFonts.Contains(PredefinedSettings.DefaultFonts[i]))
                     {
-                        settingsProvider.SetSetting(PredefinedSettings.TextEditorFont, PredefinedSettings.SupportedFonts[i]);
+                        settingsProvider.SetSetting(PredefinedSettings.TextEditorFont, PredefinedSettings.DefaultFonts[i]);
                         return;
                     }
                 }

--- a/src/dev/impl/DevToys/Core/Settings/PredefinedSettings.cs
+++ b/src/dev/impl/DevToys/Core/Settings/PredefinedSettings.cs
@@ -62,7 +62,7 @@ namespace DevToys.Core.Settings
                 isRoaming: true,
                 defaultValue: true);
 
-        public static readonly string[] SupportedFonts
+        public static readonly string[] DefaultFonts
             = new[]
             {
                 "Fira Code",

--- a/src/dev/impl/DevToys/ViewModels/Tools/Settings/SettingsToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Settings/SettingsToolViewModel.cs
@@ -131,7 +131,7 @@ namespace DevToys.ViewModels.Settings
             RateAndReviewCommand = new AsyncRelayCommand(ExecuteRateAndReviewCommandAsync);
             OpenLogsCommand = new AsyncRelayCommand(ExecuteOpenLogsCommandAsync);
 
-            LoadSupportedFontsAsync().Forget();
+            LoadFonts();
         }
 
         #region CopyVersionCommand
@@ -224,18 +224,13 @@ namespace DevToys.ViewModels.Settings
 
         #endregion
 
-        private async Task LoadSupportedFontsAsync()
+        private void LoadFonts()
         {
-            await TaskScheduler.Default;
-
             string[] systemFonts = CanvasTextFormat.GetSystemFontFamilies();
 
-            for (int i = 0; i < PredefinedSettings.SupportedFonts.Length; i++)
+            for (int i = 0; i < systemFonts.Length; i++)
             {
-                if (systemFonts.Contains(PredefinedSettings.SupportedFonts[i]))
-                {
-                    SupportedFonts.Add(PredefinedSettings.SupportedFonts[i]);
-                }
+                SupportedFonts.Add(systemFonts[i]);
             }
 
             OnPropertyChanged(nameof(TextEditorFont));

--- a/src/dev/impl/DevToys/Views/Tools/Settings/SettingsToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Settings/SettingsToolPage.xaml
@@ -86,6 +86,11 @@
             <ComboBox
                 ItemsSource="{x:Bind ViewModel.SupportedFonts, Mode=OneWay}"
                 SelectedValue="{x:Bind ViewModel.TextEditorFont, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding}" FontFamily="{Binding}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
             </ComboBox>
         </controls:ExpandableSettingControl>
         <controls:ExpandableSettingControl


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

This PR will allow users to use any font they want in DevToys text editor.

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [x] Other (please describe): Improvement of font settings

## What is the current behavior?

User was limited to a very few amount of fonts.

Issue Number: #34

## What is the new behavior?

Users can now select any font installed on the system.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [ ] Checked all unit tests pass