### PR TITLE
Fixed a bug where Monaco Editor isn't clickable when NavigationView is in Compact state.

### DIFF
--- a/src/dev/impl/DevToys/Views/MainPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/MainPage.xaml.cs
@@ -69,6 +69,10 @@ namespace DevToys.Views
 
             NotificationControl.NotificationService = _mefProvider!.Import<INotificationService>();
 
+            // Bug #54: Force to go to Expanded visual state on start fix an issue where starting the app
+            //          with a size that made the app going to Compact state break the layout and Monaco Editor.
+            VisualStateManager.GoToState(this, NavigationViewExpandedStateName, useTransitions: true);
+
             UpdateVisualState();
         }
 


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

When the app starts with NavigationView in Compact mode, the layout seems broken and Monaco Editor can't be focused until the app goes to Expanded mode (and goes back to Compact, if wanted).

![image](https://user-images.githubusercontent.com/3747805/139594917-c50f7da8-d24f-4dbf-95ee-ada9cb57cc70.png)

Issue Number: #54 

## What is the new behavior?

Fixed the issue by forcing the view to start in Expanded view, and then switch to Compact view is needed.

## Quality check

Before creating this PR, have you:

- [X] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [ ] Checked all unit tests pass