### PR TITLE
Number Base Converter smart detection for Hexadecimal and Binary

### DIFF
--- a/src/dev/impl/DevToys/DevToys.csproj
+++ b/src/dev/impl/DevToys/DevToys.csproj
@@ -24,6 +24,7 @@
     <Compile Include="Api\Core\OOP\IAppService.cs" />
     <Compile Include="Core\OOP\AppService.cs" />
     <Compile Include="Core\Threading\AsyncLazy.cs" />
+    <Compile Include="Helpers\NumberBaseHelper.cs" />
     <Compile Include="Models\Radix.cs" />
     <Compile Include="Models\NumberBaseFormat.cs" />
     <Compile Include="UI\Converters\BooleanToDoubleConverter.cs" />

--- a/src/dev/impl/DevToys/Helpers/NumberBaseHelper.cs
+++ b/src/dev/impl/DevToys/Helpers/NumberBaseHelper.cs
@@ -1,0 +1,53 @@
+﻿#nullable enable
+
+using System.Globalization;
+using DevToys.Core.Formatter;
+
+namespace DevToys.Helpers
+{
+    internal static class NumberBaseHelper
+    {
+        /// <summary>
+        /// Detects whether the given string is a valid Hexadecimal Number or not.
+        /// </summary>
+        internal static bool IsValidHexadecimal(string? input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return false;
+            }
+
+            long.TryParse(input, NumberStyles.HexNumber, null, out long output);
+            if (output is not 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Detects whether the given string is a valid Binary Number or not.
+        /// </summary>
+        internal static bool IsValidBinary(string? input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return false;
+            }
+
+            input = input!.Replace("\0", string.Empty);
+
+            foreach (char @char in input!)
+            {
+                if (@char is not '0' and not '1')
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+    }
+}

--- a/src/dev/impl/DevToys/ViewModels/Tools/NumberBaseConverter/NumberBaseConverterToolProvider.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/NumberBaseConverter/NumberBaseConverterToolProvider.cs
@@ -3,7 +3,9 @@
 using System.Composition;
 using System.Threading.Tasks;
 using DevToys.Api.Tools;
+using DevToys.Core.Formatter;
 using DevToys.Core.Threading;
+using DevToys.Helpers;
 using DevToys.Shared.Api.Core;
 using Windows.UI.Xaml.Controls;
 
@@ -21,7 +23,6 @@ namespace DevToys.ViewModels.Tools.NumberBaseConverter
         public string DisplayName => LanguageManager.Instance.NumberBaseConverter.DisplayName;
 
         public string AccessibleName => LanguageManager.Instance.NumberBaseConverter.AccessibleName;
-
 
         public object IconSource
             => new TaskCompletionNotifier<IconElement>(
@@ -42,7 +43,8 @@ namespace DevToys.ViewModels.Tools.NumberBaseConverter
 
         public bool CanBeTreatedByTool(string data)
         {
-            return false;
+            data = NumberBaseFormatter.RemoveFormatting(data).ToString();
+            return NumberBaseHelper.IsValidBinary(data) || NumberBaseHelper.IsValidHexadecimal(data);
         }
 
         public IToolViewModel CreateTool()

--- a/src/dev/impl/DevToys/Views/Tools/NumberBaseConverter/NumberBaseConverterToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/NumberBaseConverter/NumberBaseConverterToolPage.xaml.cs
@@ -1,6 +1,9 @@
 ﻿#nullable enable
 
 using DevToys.Api.Core.Navigation;
+using DevToys.Core.Formatter;
+using DevToys.Helpers;
+using DevToys.Models;
 using DevToys.Shared.Core;
 using DevToys.ViewModels.Tools.NumberBaseConverter;
 using Windows.UI.Xaml;
@@ -34,14 +37,30 @@ namespace DevToys.Views.Tools.NumberBaseConverter
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            var parameters = (NavigationParameter)e.Parameter;
+
             if (ViewModel is null)
             {
-                var parameters = (NavigationParameter)e.Parameter;
-
                 // Set the view model
                 Assumes.NotNull(parameters.ViewModel, nameof(parameters.ViewModel));
                 ViewModel = (NumberBaseConverterToolViewModel)parameters.ViewModel!;
                 DataContext = ViewModel;
+            }
+
+            if (!string.IsNullOrWhiteSpace(parameters.ClipBoardContent))
+            {
+                string clipBoardContent = NumberBaseFormatter.RemoveFormatting(parameters.ClipBoardContent).ToString();
+
+                if (NumberBaseHelper.IsValidBinary(clipBoardContent!))
+                {
+                    ViewModel.InputBaseNumber = NumberBaseFormat.Binary;
+                }
+                else if (NumberBaseHelper.IsValidHexadecimal(clipBoardContent!))
+                {
+                    ViewModel.InputBaseNumber = NumberBaseFormat.Hexadecimal;
+                }
+
+                ViewModel.InputValue = parameters.ClipBoardContent;
             }
 
             base.OnNavigatedTo(e);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

If the user has a content in is clipboard that can be treated by the Number Base Converter, the toy is not highlighted.

Issue Number: #87 

## What is the new behavior?

If the user has a content in is clipboard that can be treated by the Number Base Converter.
- the toy will be highlighted.
- if it's the only toy that can handle this content, it will be loaded
- the clipboard content will be past and the matching input will be selected

## Quality check

Before creating this PR, have you:

- [X] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [X] Checked all unit tests pass