### PR TITLE
Fixes #94 where DevToys takes several seconds to shutdown after using PNG / JPEG Compressor tool.

### DIFF
--- a/src/dev/impl/DevToys.OutOfProcService/API/Core/OOP/IOutOfProcService.cs
+++ b/src/dev/impl/DevToys.OutOfProcService/API/Core/OOP/IOutOfProcService.cs
@@ -13,6 +13,6 @@ namespace DevToys.OutOfProcService.API.Core.OOP
 
         event EventHandler<AppServiceProgressMessageEventArgs>? ReportProgress;
 
-        Task<AppServiceMessageBase> ProcessMessageAsync(AppServiceMessageBase inputMessage, CancellationToken cancellationToken);
+        Task<AppServiceMessageBase?> ProcessMessageAsync(AppServiceMessageBase inputMessage, CancellationToken cancellationToken);
     }
 }

--- a/src/dev/impl/DevToys.OutOfProcService/Core/OOP/AppService.cs
+++ b/src/dev/impl/DevToys.OutOfProcService/Core/OOP/AppService.cs
@@ -208,11 +208,14 @@ namespace DevToys.OutOfProcService.Core.OOP
                 service.ReportProgress += Service_ReportProgress;
 
                 // Invoke the service.
-                AppServiceMessageBase outputMessage = await service.ProcessMessageAsync(inputMessage, cancellationToken);
-                outputMessage.MessageId = inputMessage.MessageId;
+                AppServiceMessageBase? outputMessage = await service.ProcessMessageAsync(inputMessage, cancellationToken);
+                if (outputMessage is not null)
+                {
+                    outputMessage.MessageId = inputMessage.MessageId;
 
-                // Send the service result as a response to the UWP app.
-                await SendMessageAsync(outputMessage);
+                    // Send the service result as a response to the UWP app.
+                    await SendMessageAsync(outputMessage);
+                }
             }
             catch (OperationCanceledException)
             {

--- a/src/dev/impl/DevToys.OutOfProcService/OutOfProcServices/OutOfProcServiceBase.cs
+++ b/src/dev/impl/DevToys.OutOfProcService/OutOfProcServices/OutOfProcServiceBase.cs
@@ -10,7 +10,7 @@ namespace DevToys.OutOfProcService.OutOfProcServices
 {
     internal abstract class OutOfProcServiceBase<TInput, TOutput> : IOutOfProcService
         where TInput : AppServiceMessageBase
-        where TOutput : AppServiceMessageBase
+        where TOutput : AppServiceMessageBase?
     {
         private readonly DisposableSempahore _sempahore = new();
         private bool _messageIsProcessing;
@@ -19,7 +19,7 @@ namespace DevToys.OutOfProcService.OutOfProcServices
 
         public event EventHandler<AppServiceProgressMessageEventArgs>? ReportProgress;
 
-        public async Task<AppServiceMessageBase> ProcessMessageAsync(AppServiceMessageBase inputMessage, CancellationToken cancellationToken)
+        public async Task<AppServiceMessageBase?> ProcessMessageAsync(AppServiceMessageBase inputMessage, CancellationToken cancellationToken)
         {
             Assumes.NotNull(inputMessage.MessageId, nameof(inputMessage.MessageId));
 

--- a/src/dev/impl/DevToys.OutOfProcService/OutOfProcServices/ShutdownService.cs
+++ b/src/dev/impl/DevToys.OutOfProcService/OutOfProcServices/ShutdownService.cs
@@ -3,12 +3,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using DevToys.OutOfProcService.API.Core.OOP;
 using DevToys.OutOfProcService.Core.OOP;
+using DevToys.Shared.Core.OOP;
 
 namespace DevToys.OutOfProcService.OutOfProcServices
 {
     [Export(typeof(IOutOfProcService))]
     [InputType(typeof(ShutdownMessage))]
-    internal sealed class ShutdownService : OutOfProcServiceBase<ShutdownMessage, ShutdownMessage>
+    internal sealed class ShutdownService : OutOfProcServiceBase<ShutdownMessage, AppServiceMessageBase?>
     {
         private readonly AppService _appService;
 
@@ -18,10 +19,10 @@ namespace DevToys.OutOfProcService.OutOfProcServices
             _appService = appService;
         }
 
-        protected override Task<ShutdownMessage> ProcessMessageAsync(ShutdownMessage inputMessage, CancellationToken cancellationToken)
+        protected override Task<AppServiceMessageBase?> ProcessMessageAsync(ShutdownMessage inputMessage, CancellationToken cancellationToken)
         {
             _appService.IndicateAppServiceConnectionLost();
-            return Task.FromResult(inputMessage);
+            return Task.FromResult<AppServiceMessageBase?>(null);
         }
     }
 }

--- a/src/dev/impl/DevToys/Api/Core/OOP/IAppService.cs
+++ b/src/dev/impl/DevToys/Api/Core/OOP/IAppService.cs
@@ -10,6 +10,8 @@ namespace DevToys.Api.Core.OOP
     /// </summary>
     public interface IAppService
     {
+        Task SendMessageAsync(AppServiceMessageBase message);
+
         Task<T> SendMessageAndGetResponseAsync<T>(AppServiceMessageBase message) where T : AppServiceMessageBase;
 
         Task<T> SendMessageAndGetResponseAsync<T>(AppServiceMessageBase message, CancellationToken cancellationToken) where T : AppServiceMessageBase;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

After using the Win32 app service (through PNG / JPEG Compressor tool, for example), when closing DevToys, the UWP process takes several seconds to stop and end up on a crash.

Issue Number: #94

## What is the new behavior?

The issue is caused by the Shutdown AppService message. In short, this message shut down the Win32 app. Meanwhile, DevToys' UWP app is waiting for an answer from the Win32 process. Since the process shut down, there's no answer to expect.
The fix is to allow to send a message to the Win32 app without expecting any response.

## Quality check

Before creating this PR, have you:

- [X] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [ ] Checked all unit tests pass