### PR TITLE
hide the child pane on compact mode

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/MainPageViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/MainPageViewModel.cs
@@ -453,16 +453,15 @@ namespace DevToys.ViewModels
                     _pasteInFirstSelectedToolIsAllowed = false;
 
                     IDisposable? menuItemShouldBeExpandedLock = null;
-                    if (programmaticalSelection)
+                    if (programmaticalSelection && NavigationViewDisplayMode is NavigationViewDisplayMode.Expanded)
                     {
                         menuItemShouldBeExpandedLock = value.ForceMenuItemShouldBeExpanded();
                     }
-
                     Messenger.Send(new NavigateToToolMessage(toolViewModel, clipboardContentData));
+
                     OnPropertyChanged(nameof(SelectedMenuItem));
                     OnPropertyChanged(nameof(HeaderText));
                     OnPropertyChanged(nameof(WindowTitle));
-
                     menuItemShouldBeExpandedLock?.Dispose();
                 }
             }

--- a/src/dev/impl/DevToys/Views/MainPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/MainPage.xaml.cs
@@ -115,12 +115,14 @@ namespace DevToys.Views
         private void NavigationView_PaneClosing(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs args)
         {
             ViewModel.IsNavigationViewPaneOpened = false;
+            ViewModel.NavigationViewDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Compact;
             UpdateVisualState();
         }
 
         private void NavigationView_PaneOpening(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
         {
             ViewModel.IsNavigationViewPaneOpened = true;
+            ViewModel.NavigationViewDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Expanded;
             UpdateVisualState();
         }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

When the sidebar is collapse and the user click on a toys the child pane is displayed over the toys

Issue Number: #116 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
When the user click on a toys when the sidebar is collapse the child pane is not displayed

## Quality check

Before creating this PR, have you:

- [X] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [ ] Checked all unit tests pass