### PR TITLE
Enable decoding of unpadded base64 strings

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/Base64EncoderDecoder/Base64EncoderDecoderToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/Base64EncoderDecoder/Base64EncoderDecoderToolViewModel.cs
@@ -201,6 +201,13 @@ namespace DevToys.ViewModels.Tools.Base64EncoderDecoder
                 return string.Empty;
             }
 
+            int remainder = data!.Length % 4;
+            if (remainder > 0)
+            {
+                int padding = 4 - remainder;
+                data = data.PadRight(data.Length + padding, '=');
+            }
+
             await TaskScheduler.Default;
             string? decoded = string.Empty;
 

--- a/src/tests/DevToys.Tests/Providers/Tools/Base64EncoderDecoderTests.cs
+++ b/src/tests/DevToys.Tests/Providers/Tools/Base64EncoderDecoderTests.cs
@@ -54,6 +54,7 @@ namespace DevToys.Tests.Providers.Tools
         [DataRow("", "")]
         [DataRow(" ", "")]
         [DataRow("SGVsbG8gVGhlcmU=", "Hello There")]
+        [DataRow("SGVsbG8gVGhlcmU", "Hello There")]
         public async Task DecodeAsync(string input, string expectedResult)
         {
             Base64EncoderDecoderToolViewModel viewModel = ExportProvider.Import<Base64EncoderDecoderToolViewModel>();


### PR DESCRIPTION
Closes #178

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behaviour?

<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->
Pasting a base64 string without the final '=' can not be decoded.


Issue Number: #178 

## What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. -->

Pasting a base64 string without final '=' will add the final '=' to the data to be decoded. Input data in the form is not modified.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [x ] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration // Storage full, currently can't build
- [x ] Checked all unit tests pass