### PR TITLE
Updated ValueOverflow exception to use localised error message.

### DIFF
--- a/src/dev/impl/DevToys/Strings/en-US/NumberBaseConverter.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/NumberBaseConverter.resw
@@ -148,7 +148,7 @@
     <value>Decimal</value>
   </data>
   <data name="InputTypeDescription" xml:space="preserve">
-    <value>Select which Input type you want to use</value>
+    <value>Select which input type you want to use</value>
   </data>
   <data name="InputTypeHexadecimal" xml:space="preserve">
     <value>Hexadecimal</value>
@@ -167,7 +167,7 @@
     <comment>The parameter is the Base Number Type (Decimal, Octal, ...)</comment>
   </data>
   <data name="ValueOverflow" xml:space="preserve">
-    <value>Unable to parse the current value exceed max value {0}</value>
+    <value>The current value cannot be converted as it exceeds the maximum value ({0})</value>
     <comment>The parameter is the Max value of a long</comment>
   </data>
   <data name="Description" xml:space="preserve">

--- a/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseFormatter.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseFormatter.cs
@@ -222,14 +222,14 @@ namespace DevToys.Core.Formatter
                     // Check for overflows - this is sufficient & correct.
                     if (result > maxVal)
                     {
-                        throw new OverflowException($"Unable to parse the current value exceded max value ({long.MaxValue})");
+                        throw new OverflowException(string.Format(Strings.ValueOverflow, long.MaxValue));
                     }
 
                     ulong temp = result * (ulong)baseNumber.BaseNumber + (ulong)current;
 
                     if (temp < result) // this means overflow as well
                     {
-                        throw new OverflowException($"Unable to parse the current value exceded max value ({long.MaxValue})");
+                        throw new OverflowException(string.Format(Strings.ValueOverflow, long.MaxValue));
                     }
 
                     result = temp;


### PR DESCRIPTION
Updated ValueOverflow exception to use localised error message.
Also corrected grammar and capitalisation (for English)

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Localised exception message for Number Base Converter only displays if Input Type is Decimal, this error message has poor grammar
Issue Number: #150

## What is the new behavior?
- Inputting a too large number will always display a localised warning message
- Warning message has better grammar
- Removed random capital in "Input" from InputTypeDescription

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass