### PR TITLE
Fixing hex string validation. "0" was not an accepted hex value

### DIFF
--- a/src/dev/impl/DevToys/Helpers/NumberBaseHelper.cs
+++ b/src/dev/impl/DevToys/Helpers/NumberBaseHelper.cs
@@ -16,13 +16,7 @@ namespace DevToys.Helpers
                 return false;
             }
 
-            long.TryParse(input, NumberStyles.HexNumber, null, out long output);
-            if (output is not 0)
-            {
-                return true;
-            }
-
-            return false;
+            return long.TryParse(input, NumberStyles.HexNumber, null, out _);
         }
 
         /// <summary>


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

The hexadecimal string "0" was not accepted as a correct hex value.

Issue Number: N/A

## What is the new behavior?

Now the method accept "0" and any other correct hexadecimal string

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [ ] Checked all unit tests pass