### PR TITLE
Fixed French translation [fr-FR]

### DIFF
--- a/src/dev/impl/DevToys/Strings/fr-FR/ToolGroups.resw
+++ b/src/dev/impl/DevToys/Strings/fr-FR/ToolGroups.resw
@@ -142,10 +142,10 @@
     <value>Générateurs</value>
   </data>
   <data name="GraphicAccessibleName" xml:space="preserve">
-    <value>Gaphique</value>
+    <value>Graphique</value>
   </data>
   <data name="GraphicDisplayName" xml:space="preserve">
-    <value>Gaphique</value>
+    <value>Graphique</value>
   </data>
   <data name="TextAccessibleName" xml:space="preserve">
     <value>Texte</value>


### PR DESCRIPTION
Fix a typo in tool "Graphic", in French language

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

The Graphic tool is translated by "Gaphique" in french

## What is the new behavior?

Now, the Graphic tool is translated by "Graphique" in french

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [ ] Checked all unit tests pass