### PR TITLE
HashGenerator output on base64 or hex

### DIFF
--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -640,6 +640,21 @@ namespace DevToys
         /// Gets the resource SearchDisplayName.
         /// </summary>
         public string SearchDisplayName => _resources.GetString("SearchDisplayName");
+
+        /// <summary>
+        /// Gets the resource OutputBase64.
+        /// </summary>
+        public string OutputBase64 => _resources.GetString("OutputBase64");
+
+        /// <summary>
+        /// Gets the resource OutputHex.
+        /// </summary>
+        public string OutputHex => _resources.GetString("OutputHex");
+
+        /// <summary>
+        /// Gets the resource OutputTypeTitle.
+        /// </summary>
+        public string OutputTypeTitle => _resources.GetString("OutputTypeTitle");
     }
 
     public class HtmlEncoderDecoderStrings : ObservableObject

--- a/src/dev/impl/DevToys/Strings/cs-CZ/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/cs-CZ/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Hash Generátor</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Typ výstupu</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/de-DE/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/de-DE/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Hash Generator</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Ausgabetyp</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/en-US/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Hash Generator</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Output Type</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/es-AR/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/es-AR/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Generador de Hash</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Tipo de Salida</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/es-ES/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/es-ES/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Generador de Hash</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Tipo de Salida</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/fr-FR/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/fr-FR/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Générateur de Hash</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Le type de sortie</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/hu-HU/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/hu-HU/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Hash Generátor</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Kimenet típusa</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/id-ID/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/id-ID/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Pembuat Hash</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Jenis keluaran</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/ja-JP/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/ja-JP/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>ハッシュ生成ツール</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>出力タイプ</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/pl-PL/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/pl-PL/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Generator Hash'y</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Typ wyjścia</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/pt-PT/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/pt-PT/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Gerador de Hash</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Tipo de saída</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/ru-RU/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/ru-RU/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>Генерирование Hash</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>Тип выхода</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/zh-Hans/HashGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/zh-Hans/HashGenerator.resw
@@ -150,4 +150,13 @@
   <data name="SearchDisplayName" xml:space="preserve">
     <value>哈希散列（Hash）生成工具</value>
   </data>
+  <data name="OutputBase64" xml:space="preserve">
+    <value>Base64</value>
+  </data>
+  <data name="OutputHex" xml:space="preserve">
+    <value>Hex</value>
+  </data>
+  <data name="OutputTypeTitle" xml:space="preserve">
+    <value>輸出類型</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/HashGenerator/HashGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/HashGenerator/HashGeneratorToolViewModel.cs
@@ -50,7 +50,9 @@ namespace DevToys.ViewModels.Tools.HashGenerator
         private string? _sha1;
         private string? _sha256;
         private string? _sha512;
-        private const string DefaultOutputType = "Hex";
+        private const string HexOutput = "Hex";
+        private const string Base64Output = "Base64";
+        private const string DefaultOutputType = HexOutput;
 
         public Type View { get; } = typeof(HashGeneratorToolPage);
 
@@ -186,11 +188,11 @@ namespace DevToys.ViewModels.Tools.HashGenerator
                 buffer = algorithmProvider.HashData(buffer);
 
                 string? hash="";
-                if (OutputType == "Hex")
+                if (string.Equals(OutputType, HexOutput))
                 {
                     hash = CryptographicBuffer.EncodeToHexString(buffer);
                 }
-                else if (OutputType == "Base64")
+                else if (string.Equals(OutputType, Base64Output))
                 {
                     hash = CryptographicBuffer.EncodeToBase64String(buffer);
                 }

--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/HashGenerator/HashGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/HashGenerator/HashGeneratorToolViewModel.cs
@@ -30,6 +30,15 @@ namespace DevToys.ViewModels.Tools.HashGenerator
                 isRoaming: true,
                 defaultValue: false);
 
+        /// <summary>
+        /// The Output Code to generate.
+        /// </summary>
+        private static readonly SettingDefinition<string> OutType
+            = new(
+                name: $"{nameof(HashGeneratorToolViewModel)}.{nameof(OutType)}",
+                isRoaming: true,
+                defaultValue: DefaultOutputType);
+
         private readonly IMarketingService _marketingService;
         private readonly ISettingsProvider _settingsProvider;
         private readonly Queue<string> _hashCalculationQueue = new();
@@ -41,6 +50,7 @@ namespace DevToys.ViewModels.Tools.HashGenerator
         private string? _sha1;
         private string? _sha256;
         private string? _sha512;
+        private const string DefaultOutputType = "Hex";
 
         public Type View { get; } = typeof(HashGeneratorToolPage);
 
@@ -54,6 +64,20 @@ namespace DevToys.ViewModels.Tools.HashGenerator
                 if (_settingsProvider.GetSetting(Uppercase) != value)
                 {
                     _settingsProvider.SetSetting(Uppercase, value);
+                    OnPropertyChanged();
+                    QueueHashCalculation();
+                }
+            }
+        }
+
+        internal string OutputType
+        {
+            get => _settingsProvider.GetSetting(OutType);
+            set
+            {
+                if (_settingsProvider.GetSetting(OutType) != value)
+                {
+                    _settingsProvider.SetSetting(OutType, value);
                     OnPropertyChanged();
                     QueueHashCalculation();
                 }
@@ -161,7 +185,15 @@ namespace DevToys.ViewModels.Tools.HashGenerator
                 IBuffer buffer = CryptographicBuffer.ConvertStringToBinary(text, BinaryStringEncoding.Utf8);
                 buffer = algorithmProvider.HashData(buffer);
 
-                string? hash = CryptographicBuffer.EncodeToHexString(buffer);
+                string? hash="";
+                if (OutputType == "Hex")
+                {
+                    hash = CryptographicBuffer.EncodeToHexString(buffer);
+                }
+                else if (OutputType == "Base64")
+                {
+                    hash = CryptographicBuffer.EncodeToBase64String(buffer);
+                }
 
                 if (IsUppercase)
                 {

--- a/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml
@@ -27,6 +27,19 @@
                     Style="{StaticResource RightAlignedToggleSwitchStyle}"
                     IsOn="{x:Bind ViewModel.IsUppercase, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
             </controls:ExpandableSettingControl>
+            <controls:ExpandableSettingControl
+                TabIndex="0"
+                Title="{x:Bind ViewModel.Strings.OutputTypeTitle}">
+                <controls:ExpandableSettingControl.Icon>
+                    <FontIcon Glyph="&#xF587;" />
+                </controls:ExpandableSettingControl.Icon>
+                <ComboBox
+                    SelectedValuePath="Tag"
+                    SelectedValue="{x:Bind ViewModel.OutputType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    <ComboBoxItem Tag="Hex" Content="{x:Bind ViewModel.Strings.OutputHex}" />
+                    <ComboBoxItem Tag="Base64" Content="{x:Bind ViewModel.Strings.OutputBase64}"/>
+                </ComboBox>
+            </controls:ExpandableSettingControl>
         </StackPanel>
 
         <controls:CustomTextBox


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

The output of a hash generation is always Hex. Sometimes is useful for the output to be in base64.

Issue Number: #239 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- An option to select the Output Type between Hex and Base64 has been added