### PR TITLE
Add a copy button to the MarkdownPreview tool to copy the HTML output

### DIFF
--- a/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml
@@ -76,11 +76,26 @@
 
             <toolkit:HeaderedContentControl
                 Grid.Column="2"
-                Header="{x:Bind ViewModel.Strings.Output}"
-                Margin="0,16,0,0"
+                Margin="0,0,0,0"
                 MinHeight="150"
                 HorizontalContentAlignment="Stretch"
                 VerticalContentAlignment="Stretch">
+                <toolkit:HeaderedContentControl.Header>
+                    <toolkit:DockPanel>
+                        <TextBlock VerticalAlignment="Bottom" Text="{x:Bind ViewModel.Strings.Output}"></TextBlock>
+                        <Button
+                            x:Name="CopyButton"
+                            TabIndex="2"
+                            HorizontalAlignment="Right"
+                            AutomationProperties.Name="{Binding Instance.Common.Copy, Mode=OneTime, Source={StaticResource LanguageManager}}"
+                            Click="CopyButton_Click">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <FontIcon Glyph="&#xF32B;"/>
+                                <TextBlock VerticalAlignment="Center" Text="{Binding Instance.Common.Copy, Mode=OneTime, Source={StaticResource LanguageManager}}"/>
+                            </StackPanel>
+                        </Button>
+                    </toolkit:DockPanel>
+                </toolkit:HeaderedContentControl.Header>
                 <Border
                     CornerRadius="4"
                     Margin="0,8,0,0"

--- a/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml
@@ -88,7 +88,7 @@
                             TabIndex="2"
                             HorizontalAlignment="Right"
                             AutomationProperties.Name="{Binding Instance.Common.Copy, Mode=OneTime, Source={StaticResource LanguageManager}}"
-                            Click="CopyButton_Click">
+                            Command="{x:Bind ViewModel.CopyHtmlCommand}">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <FontIcon Glyph="&#xF32B;"/>
                                 <TextBlock VerticalAlignment="Center" Text="{Binding Instance.Common.Copy, Mode=OneTime, Source={StaticResource LanguageManager}}"/>

--- a/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml.cs
@@ -1,13 +1,17 @@
 ﻿#nullable enable
 
+using System;
 using DevToys.Api.Core.Navigation;
+using DevToys.Core;
 using DevToys.Messages;
 using DevToys.Shared.Core;
 using DevToys.ViewModels.Tools.MarkdownPreview;
 using Microsoft.Toolkit.Mvvm.Messaging;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
+using Clipboard = Windows.ApplicationModel.DataTransfer.Clipboard;
 
 namespace DevToys.Views.Tools.MarkdownPreview
 {
@@ -64,6 +68,26 @@ namespace DevToys.Views.Tools.MarkdownPreview
         {
             Arguments.NotNull(message, nameof(message));
             PreviewWebView.NavigateToString(message.Html);
+        }
+
+        private async void CopyButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var data = new DataPackage
+                {
+                    RequestedOperation = DataPackageOperation.Copy
+                };
+                string markdownBodyEl = "document.getElementsByClassName('markdown-body')[0].innerHTML";
+                data.SetText(await PreviewWebView.InvokeScriptAsync("eval", new string[] { markdownBodyEl }) ?? string.Empty);
+
+                Clipboard.SetContentWithOptions(data, new ClipboardContentOptions() { IsAllowedInHistory = true, IsRoamable = true });
+                Clipboard.Flush();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogFault("Failed to copy from webview", ex);
+            }
         }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml.cs
@@ -1,17 +1,13 @@
 ﻿#nullable enable
 
-using System;
 using DevToys.Api.Core.Navigation;
-using DevToys.Core;
 using DevToys.Messages;
 using DevToys.Shared.Core;
 using DevToys.ViewModels.Tools.MarkdownPreview;
 using Microsoft.Toolkit.Mvvm.Messaging;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-using Clipboard = Windows.ApplicationModel.DataTransfer.Clipboard;
 
 namespace DevToys.Views.Tools.MarkdownPreview
 {
@@ -68,26 +64,6 @@ namespace DevToys.Views.Tools.MarkdownPreview
         {
             Arguments.NotNull(message, nameof(message));
             PreviewWebView.NavigateToString(message.Html);
-        }
-
-        private async void CopyButton_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                var data = new DataPackage
-                {
-                    RequestedOperation = DataPackageOperation.Copy
-                };
-                string markdownBodyEl = "document.getElementsByClassName('markdown-body')[0].innerHTML";
-                data.SetText(await PreviewWebView.InvokeScriptAsync("eval", new string[] { markdownBodyEl }) ?? string.Empty);
-
-                Clipboard.SetContentWithOptions(data, new ClipboardContentOptions() { IsAllowedInHistory = true, IsRoamable = true });
-                Clipboard.Flush();
-            }
-            catch (Exception ex)
-            {
-                Logger.LogFault("Failed to copy from webview", ex);
-            }
         }
     }
 }


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

There is no way to copy the HTML output from the markdown preview.

Issue Number: N/A

## What is the new behavior?

A new copy button above the `Webview` control allows the user to copy the contents of the `markdown-body` element.

<details>
<summary>Screenshot</summary>

<img width="902" alt="Screenshot 2022-01-25 181200" src="https://user-images.githubusercontent.com/1466314/151097893-8f9c2d4f-e9a1-422d-81bb-49aa59fcfa66.png">

</details>

## Other information

I am a newbie at UWP app development and especially with the MVVM pattern.

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
  - I could not get this to work on my machine for some reason even though my changes should not affect the Release build config. I was getting an error about a `SetVersion` task being unable to run because `Microsoft.Build.Utilities` version `3.5.0.0` wasn't available despite having a successful Nuget restore.
- [x] Checked all unit tests pass