### PR TITLE
Fix CheckSum computation cancellation 

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
@@ -66,6 +66,7 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
         private bool _hasCancelledCalculation;
         private bool _shouldDisplayProgress;
         private HashingAlgorithmDisplayPair? _outputHashingAlgorithm;
+        private Queue<Task> _computationTaskQueue = new();
 
         internal CheckSumGeneratorStrings Strings => LanguageManager.Instance.CheckSumGenerator;
 
@@ -161,7 +162,6 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
             HashingAlgorithmDisplayPair.SHA384,
             HashingAlgorithmDisplayPair.SHA512,
         };
-
 
         [ImportingConstructor]
         public CheckSumGeneratorToolViewModel(ISettingsProvider settingsProvider, IMarketingService marketingService)
@@ -282,9 +282,9 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
             lock (_lockObject)
             {
                 _hasCancelledCalculation = true;
+                
                 _cancellationTokenSource.Cancel();
                 _cancellationTokenSource.Dispose();
-
                 _cancellationTokenSource = new CancellationTokenSource();
 
                 if (shouldRevertHashingAlgo && _outputHashingAlgorithm != null)
@@ -295,6 +295,7 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
                 _isCalculationInProgress = false;
                 _hasCancelledCalculation = false;
                 ShouldDisplayProgress = false;
+
                 ResetProgress();
             }
         }
@@ -323,7 +324,7 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
             lock (_lockObject)
             {
                 ExecuteCancelCommand(shouldRevertHashingAlgo: false);
-                CheckSumAsync().Forget();
+                _computationTaskQueue.Enqueue(CheckSumAsync());
             }
         }
 
@@ -338,6 +339,11 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
 
             await TaskScheduler.Default;
 
+            if (_computationTaskQueue.Count > 1)
+            {
+                await _computationTaskQueue.Dequeue();
+            }
+
             using Stream? fileStream = await InputFile.OpenStreamForReadAsync();
 
             await ThreadHelper.RunOnUIThreadAsync(() => ShouldDisplayProgress = HashingHelper.ComputeHashIterations(fileStream) > _displayAboveIterations);
@@ -346,14 +352,14 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
 
             await ThreadHelper.RunOnUIThreadAsync(() =>
             {
+                _isCalculationInProgress = false;
+                ShouldDisplayProgress = false;
+
                 if (hashOutput != null)
                 {
                     Output = hashOutput;
                     _outputHashingAlgorithm = InputHashingAlgorithm;
                 }
-
-                _isCalculationInProgress = false;
-                ShouldDisplayProgress = false;
 
                 if (!_toolSuccessfullyWorked)
                 {
@@ -361,6 +367,8 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
                     _marketingService.NotifyToolSuccessfullyWorked();
                 }
             });
+
+            _ = _computationTaskQueue.Dequeue();
         }
 
         private async Task<string?> CalculateFileHash(HashingAlgorithm inputHashingAlgorithm, Stream fileStream)
@@ -427,6 +435,5 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
                 HashingAlgorithm.SHA512 => SHA512.Create(),
                 _ => throw new ArgumentException("Hash Algorithm not supported", nameof(HashingAlgorithm))
             };
-        
     }
 }

--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
@@ -66,7 +66,7 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
         private bool _hasCancelledCalculation;
         private bool _shouldDisplayProgress;
         private HashingAlgorithmDisplayPair? _outputHashingAlgorithm;
-        private Queue<Task> _computationTaskQueue = new();
+        private readonly Queue<Task> _computationTaskQueue = new();
 
         internal CheckSumGeneratorStrings Strings => LanguageManager.Instance.CheckSumGenerator;
 

--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
@@ -324,6 +324,12 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
             lock (_lockObject)
             {
                 ExecuteCancelCommand(shouldRevertHashingAlgo: false);
+
+                if (_computationTaskQueue.Count > 0 && _computationTaskQueue.Peek().IsCompleted)
+                {
+                    _computationTaskQueue.Dequeue();
+                }
+
                 _computationTaskQueue.Enqueue(CheckSumAsync());
             }
         }
@@ -367,8 +373,6 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
                     _marketingService.NotifyToolSuccessfullyWorked();
                 }
             });
-
-            _ = _computationTaskQueue.Dequeue();
         }
 
         private async Task<string?> CalculateFileHash(HashingAlgorithm inputHashingAlgorithm, Stream fileStream)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

While computation is ongoing, if you drag a second file to be processed, the loader will disappear and fail to calculate the checksum of the second inputted file.

Issue Number: Related to #141 

## What is the new behavior?

If a second file is dragged while a first one is being processed, the first one will be canceled and will start processing the second file.

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass