### PR TITLE
Number converter fields as inputs

### DIFF
--- a/src/dev/impl/DevToys/Helpers/NumberBaseHelper.cs
+++ b/src/dev/impl/DevToys/Helpers/NumberBaseHelper.cs
@@ -16,13 +16,7 @@ namespace DevToys.Helpers
                 return false;
             }
 
-            long.TryParse(input, NumberStyles.HexNumber, null, out long output);
-            if (output is not 0)
-            {
-                return true;
-            }
-
-            return false;
+            return long.TryParse(input, NumberStyles.HexNumber, null, out _);
         }
 
         /// <summary>

--- a/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseConverterToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseConverterToolViewModel.cs
@@ -66,33 +66,73 @@ namespace DevToys.ViewModels.Tools.NumberBaseConverter
             get => _inputValue;
             set
             {
-                SetProperty(ref _inputValue, value);
+                _inputValue = value;
                 QueueFormatting();
+            }
+        }
+
+        internal string? BinaryValue
+        {
+            get => _binaryValue;
+            set
+            {
+                if (value == _binaryValue)
+                {
+                    return;
+                }
+
+                SetProperty(ref _binaryValue, value);
+                InputBaseNumber = NumberBaseFormat.Binary;
+                InputValue = NumberBaseFormatter.RemoveFormatting(BinaryValue).ToString();
             }
         }
 
         internal string? OctalValue
         {
             get => _octalValue;
-            private set => SetProperty(ref _octalValue, value);
-        }
+            set
+            {
+                if (value == _octalValue)
+                {
+                    return;
+                }
 
-        internal string? BinaryValue
-        {
-            get => _binaryValue;
-            private set => SetProperty(ref _binaryValue, value);
+                SetProperty(ref _octalValue, value);
+                InputBaseNumber = NumberBaseFormat.Octal;
+                InputValue = NumberBaseFormatter.RemoveFormatting(OctalValue).ToString();
+            }
         }
 
         internal string? DecimalValue
         {
             get => _decimalValue;
-            private set => SetProperty(ref _decimalValue, value);
+            set
+            {
+                if (value == _decimalValue)
+                {
+                    return;
+                }
+
+                SetProperty(ref _decimalValue, value);
+                InputBaseNumber = NumberBaseFormat.Decimal;
+                InputValue = NumberBaseFormatter.RemoveFormatting(DecimalValue).ToString();
+            }
         }
 
         internal string? HexaDecimalValue
         {
             get => _hexadecimalValue;
-            private set => SetProperty(ref _hexadecimalValue, value);
+            set
+            {
+                if (value == _hexadecimalValue)
+                {
+                    return;
+                }
+
+                SetProperty(ref _hexadecimalValue, value);
+                InputBaseNumber = NumberBaseFormat.Hexadecimal;
+                InputValue = NumberBaseFormatter.RemoveFormatting(HexaDecimalValue).ToString();
+            }
         }
 
         internal bool IsInfoBarOpen
@@ -120,25 +160,7 @@ namespace DevToys.ViewModels.Tools.NumberBaseConverter
                 if (InputBaseNumber != value)
                 {
                     _settingsProvider.SetSetting(BaseNumber, value.Value);
-
-                    if (InputBaseNumber == NumberBaseFormat.Octal)
-                    {
-                        InputValue = NumberBaseFormatter.RemoveFormatting(OctalValue).ToString();
-                    }
-                    else if (InputBaseNumber == NumberBaseFormat.Binary)
-                    {
-                        InputValue = NumberBaseFormatter.RemoveFormatting(BinaryValue).ToString();
-                    }
-                    else if (InputBaseNumber == NumberBaseFormat.Hexadecimal)
-                    {
-                        InputValue = NumberBaseFormatter.RemoveFormatting(HexaDecimalValue).ToString();
-                    }
-                    else
-                    {
-                        InputValue = NumberBaseFormatter.RemoveFormatting(DecimalValue).ToString();
-                    }
                     OnPropertyChanged();
-                    QueueFormatting();
                 }
             }
         }
@@ -227,10 +249,11 @@ namespace DevToys.ViewModels.Tools.NumberBaseConverter
 
                 ThreadHelper.RunOnUIThreadAsync(ThreadPriority.Low, () =>
                 {
-                    OctalValue = octalValue;
-                    BinaryValue = binaryValue;
-                    DecimalValue = decimalValue;
-                    HexaDecimalValue = hexaDecimalValue;
+                    FillPropertyValues(ref _binaryValue, binaryValue, nameof(BinaryValue), NumberBaseFormat.Binary);
+                    FillPropertyValues(ref _octalValue, octalValue, nameof(OctalValue), NumberBaseFormat.Octal);
+                    FillPropertyValues(ref _decimalValue, decimalValue, nameof(DecimalValue), NumberBaseFormat.Decimal);
+                    FillPropertyValues(ref _hexadecimalValue, hexaDecimalValue, nameof(HexaDecimalValue), NumberBaseFormat.Hexadecimal);
+
                     InfoBarMessage = infoBarMessage;
                     IsInfoBarOpen = isInfoBarOpen;
 
@@ -243,6 +266,14 @@ namespace DevToys.ViewModels.Tools.NumberBaseConverter
             }
 
             _conversionInProgress = false;
+        }
+
+        private void FillPropertyValues(ref string? property, string? value, string viewModelName, NumberBaseFormat format)
+        {
+            if (format != InputBaseNumber)
+            {
+                SetProperty(ref property, value, viewModelName);
+            }
         }
     }
 }

--- a/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseFormatter.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseFormatter.cs
@@ -141,6 +141,10 @@ namespace DevToys.ViewModels.Tools.Converters.NumberBaseConverter
         private static string FormatNumber(ReadOnlySpan<char> buffer, NumberBaseFormat baseNumber, bool isFormatted, int index)
         {
             var builder = new StringBuilder();
+            if (buffer[index - 1] == '-')
+            {
+                builder.Append(buffer[--index]);
+            }
 
             for (int builderIndex = --index; builderIndex >= 0; builderIndex--)
             {

--- a/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseFormatter.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseFormatter.cs
@@ -122,6 +122,24 @@ namespace DevToys.ViewModels.Tools.Converters.NumberBaseConverter
                 }
             }
 
+            return FormatNumber(buffer, baseNumber, isFormatted, index);
+        }
+
+        /// <summary>
+        /// Format <paramref name="number"/> based on <paramref name="baseNumber"/> format definition 
+        /// </summary>
+        /// <param name="number">String representation of the number</param>
+        /// <param name="baseNumber">Current base number <see cref="NumberBaseFormat"/></param>
+        /// <returns>Formatted number based on <paramref name="baseNumber"/> format definition</returns>
+        public static string FormatNumber(string number, NumberBaseFormat baseNumber)
+        {
+            char[] charArray = RemoveFormatting(number).ToCharArray();
+            Array.Reverse(charArray);
+            return FormatNumber(charArray, baseNumber, true, charArray.Length);
+        }
+
+        private static string FormatNumber(ReadOnlySpan<char> buffer, NumberBaseFormat baseNumber, bool isFormatted, int index)
+        {
             var builder = new StringBuilder();
 
             for (int builderIndex = --index; builderIndex >= 0; builderIndex--)

--- a/src/dev/impl/DevToys/Views/Tools/Converters/NumberBaseConverter/NumberBaseConverterToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Converters/NumberBaseConverter/NumberBaseConverterToolPage.xaml
@@ -36,19 +36,26 @@
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.HexadecimalLabel}"
             Text="{x:Bind ViewModel.HexaDecimalValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-            />
+            LostFocus="{x:Bind ViewModel.InputFocusChanged}"
+            Tag="Hexadecimal"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.DecimalLabel}"
             AcceptsReturn="False"
-            Text="{x:Bind ViewModel.DecimalValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            Text="{x:Bind ViewModel.DecimalValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            LostFocus="{x:Bind ViewModel.InputFocusChanged}"
+            Tag="Decimal"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.OctalLabel}"
-            Text="{x:Bind ViewModel.OctalValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            Text="{x:Bind ViewModel.OctalValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            LostFocus="{x:Bind ViewModel.InputFocusChanged}"
+            Tag="Octal"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.BinaryLabel}"
-            Text="{x:Bind ViewModel.BinaryValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            Text="{x:Bind ViewModel.BinaryValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            LostFocus="{x:Bind ViewModel.InputFocusChanged}"
+            Tag="Binary"/>
     </StackPanel>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Converters/NumberBaseConverter/NumberBaseConverterToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Converters/NumberBaseConverter/NumberBaseConverterToolPage.xaml
@@ -26,49 +26,29 @@
                     Style="{StaticResource RightAlignedToggleSwitchStyle}"
                     IsOn="{x:Bind ViewModel.IsFormatted, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
             </controls:ExpandableSettingControl>
-            <controls:ExpandableSettingControl
-                Grid.Row="1"
-                Title="{x:Bind ViewModel.Strings.InputTypeTitle}"
-                Description="{x:Bind ViewModel.Strings.InputTypeDescription}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF18D;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ComboBox
-                    ItemsSource="{x:Bind ViewModel.BaseNumbers}"
-                    DisplayMemberPath="DisplayName"
-                    SelectedValue="{x:Bind ViewModel.InputBaseNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                </ComboBox>
-            </controls:ExpandableSettingControl>
         </StackPanel>
-
-        <controls:CustomTextBox
-            Header="{x:Bind ViewModel.Strings.Input}"
-            AcceptsReturn="False"
-            Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
         <muxc:InfoBar 
             IsOpen="{x:Bind ViewModel.IsInfoBarOpen, Mode=OneWay}" 
             Severity="Warning" 
             Message="{x:Bind ViewModel.InfoBarMessage, Mode=OneWay}" />
-        
+
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.HexadecimalLabel}"
-            IsReadOnly="True"
-            Text="{x:Bind ViewModel.HexaDecimalValue, Mode=OneWay}"/>
+            Text="{x:Bind ViewModel.HexaDecimalValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            />
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.DecimalLabel}"
-            IsReadOnly="True"
-            Text="{x:Bind ViewModel.DecimalValue, Mode=OneWay}"/>
+            AcceptsReturn="False"
+            Text="{x:Bind ViewModel.DecimalValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.OctalLabel}"
-            IsReadOnly="True"
-            Text="{x:Bind ViewModel.OctalValue, Mode=OneWay}"/>
+            Text="{x:Bind ViewModel.OctalValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.BinaryLabel}"
-            IsReadOnly="True"
-            Text="{x:Bind ViewModel.BinaryValue, Mode=OneWay}"/>
+            Text="{x:Bind ViewModel.BinaryValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
     </StackPanel>
 </Page>

--- a/src/tests/DevToys.Tests/Providers/Tools/BaseNumberFormatterTests.cs
+++ b/src/tests/DevToys.Tests/Providers/Tools/BaseNumberFormatterTests.cs
@@ -120,5 +120,41 @@ namespace DevToys.Tests.Providers.Tools
         {
             Assert.AreEqual(expectedResult, NumberBaseFormatter.RemoveFormatting(input));
         }
+
+        [DataTestMethod]
+        [DataRow("000101001101", "0001 0100 1101")]
+        [DataRow("00 01 01 00 11 01", "0001 0100 1101")]
+        public void FormatBinary(string input, string expectedResult)
+        {
+            Assert.AreEqual(expectedResult, NumberBaseFormatter.FormatNumber(input, NumberBaseFormat.Binary));
+        }
+
+        [DataTestMethod]
+        [DataRow("2061 210 44  034 ", "206 121 044 034")]
+        [DataRow("206121044034", "206 121 044 034")]
+        public void FormatOctal(string input, string expectedResult)
+        {
+            Assert.AreEqual(expectedResult, NumberBaseFormatter.FormatNumber(input, NumberBaseFormat.Octal));
+        }
+
+        [DataTestMethod]
+        [DataRow("123456", "123,456")]
+        [DataRow("12345", "12,345")]
+        [DataRow("-123456", "-123,456")]
+        [DataRow("-12345", "-12,345")]
+        [DataRow("-12,3456", "-123,456")]
+        public void FormatDecimal(string input, string expectedResult)
+        {
+            Assert.AreEqual(expectedResult, NumberBaseFormatter.FormatNumber(input, NumberBaseFormat.Decimal));
+        }
+
+        [DataTestMethod]
+        [DataRow("C6AEA155", "C6AE A155")]
+        [DataRow("C6AE A155", "C6AE A155")]
+        [DataRow(" C 6AE A1  5 5", "C6AE A155")]
+        public void FormatHexadecimal(string input, string expectedResult)
+        {
+            Assert.AreEqual(expectedResult, NumberBaseFormatter.FormatNumber(input, NumberBaseFormat.Hexadecimal));
+        }
     }
 }


### PR DESCRIPTION
Closes #256 but with new issue lol
At the other hand, in #256 there are some features mentioned that could conflict with these new changes. The Input field now is removed, so if you want any custom number base input, then we will need to change the interface and how it works.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

You could change the numbers using any output field. Now there are some changes in the UI, as some options (number format) and Input field now become deprecated.

Issue Number: #256 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- You can use any output field as an input.

## Other information

~~Now there is a new issue... I am not sure why is happening that when the input is reformatted the text cursor returns to the left of the input field. I could keep an eye on it and try to get it solved.~~
Ok, this issue was solved with a workaround. Now the field where you decide to write the input doesn't receive any format (which could be considered as another issue)... TextBox will always reset the cursor position when updating the content, so it could be very cumbersome to design a reliable solution where cursor does not lose the position when the input should be formatted.

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass