### PR TITLE
Language - Same as Microsoft Windows

### DIFF
--- a/src/dev/impl/DevToys/LanguageDefinition.cs
+++ b/src/dev/impl/DevToys/LanguageDefinition.cs
@@ -36,19 +36,14 @@ namespace DevToys
 
         public LanguageDefinition(string? identifier)
         {
-            if (!string.IsNullOrEmpty(identifier))
+            if (string.IsNullOrEmpty(identifier))
             {
-                Culture = new CultureInfo(identifier!);
-                DisplayName = Culture.NativeName;
-                InternalName = Culture.Name;
-            }
-            else
-            {
-                Culture = CultureInfo.InstalledUICulture;
-                DisplayName = new SettingsStrings().DefaultLanguage;
-                InternalName = "default";
+                identifier = Windows.System.UserProfile.GlobalizationPreferences.Languages[0];
             }
 
+            Culture = new CultureInfo(identifier!);
+            DisplayName = Culture.NativeName;
+            InternalName = Culture.Name;
             Identifier = Culture.Name;
         }
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

When we have multiple language installed, the option **Language - Same as Microsoft Windows** doesn't select the Windows Display Culture.

Issue Number: #193
close #193

## What is the new behavior?

When we have multiple language installed, the option **Language - Same as Microsoft Windows** select the Windows Display Culture.

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [] Checked all unit tests pass