### PR TITLE
Fix octal characters validation

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseFormatter.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseFormatter.cs
@@ -271,8 +271,10 @@ namespace DevToys.ViewModels.Tools.Converters.NumberBaseConverter
                     }
                     return false;
                 case Radix.Decimal:
-                case Radix.Octal:
                     return char.IsNumber(c);
+                case Radix.Octal:
+                    return char.IsNumber(c) &&
+                        c is >= '0' and <= '7';
                 case Radix.Hexdecimal:
                     return char.IsNumber(c) ||
                         c >= 'a' && c <= 'f' ||

--- a/src/tests/DevToys.Tests/Providers/Tools/BaseNumberFormatterTests.cs
+++ b/src/tests/DevToys.Tests/Providers/Tools/BaseNumberFormatterTests.cs
@@ -49,6 +49,12 @@ namespace DevToys.Tests.Providers.Tools
         [DataTestMethod]
         [DataRow("30653520525&")]
         [DataRow("30 653 520 525 &")]
+        [DataRow("306535205258")]
+        [DataRow("30 653 520 525 8")]
+        [DataRow("306535295256")]
+        [DataRow("30 653 529 525 6")]
+        [DataRow("3065352a5256")]
+        [DataRow("3065352A5256")]
         public void OctalToDecimalShouldThrowInvalidOperationException(string input)
         {
             Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");


### PR DESCRIPTION
Octals were not correctly validated. Any number could be passed on input and the code were not complaining about it. Any calculation with an incorrect octal resulted on a input ignore.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Number as 01234567**8** were accepted as a correct octal.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Octal are correctly validated.

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass