### PR TITLE
Fix an incorrect conditional grouping that is causing an exception

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/Tools/Converters/JsonYaml/DecimalYamlTypeResolver.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Converters/JsonYaml/DecimalYamlTypeResolver.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 
@@ -13,8 +14,8 @@ namespace DevToys.ViewModels.Tools.Converters.JsonYaml
                 // avoid unnecessary parsing attempts
                 bool couldBeNumber =
                     scalar.Value.Length != 0 &&
-                    scalar.Value[0] is >= '0' and <= '9' ||
-                    scalar.Value[0] == '-';
+                    (scalar.Value[0] is >= '0' and <= '9' ||
+                    scalar.Value[0] == '-');
 
                 if (couldBeNumber && decimal.TryParse(scalar.Value, out _))
                 {


### PR DESCRIPTION
The conditional at `DecimalYamlTypeResolver` is causing an `OutOfRange` exception. It tries to evaluate the latest or condition, rising an exception when `Value` is empty.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

It rise an exception that is not a major issue, but is an unnecessary exception.

Issue Number: N/A

## What is the new behavior?

- No more exception for `DecimalYamlTypeResolver`

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass