### PR TITLE
Grammar fix: Replace "an hash" -> "a hash" in localisations

### DIFF
--- a/src/dev/impl/DevToys/Strings/de-DE/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/de-DE/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/en-US/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/es-AR/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/es-AR/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/es-ES/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/es-ES/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/fr-FR/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/fr-FR/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/hu-HU/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/hu-HU/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/id-ID/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/id-ID/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/it-IT/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/it-IT/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/pl-PL/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/pl-PL/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/ru-RU/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/ru-RU/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/zh-Hans/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/zh-Hans/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>

--- a/src/dev/impl/DevToys/Strings/zh-Hant/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/zh-Hant/CheckSumGenerator.resw
@@ -127,7 +127,7 @@
     <value>Configuration</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Generate an hash with Checksum based on a file</value>
+    <value>Generate a hash with Checksum based on a file</value>
   </data>
   <data name="HashingAlgorithmDescription" xml:space="preserve">
     <value>Select which hashing algorithm you want to use</value>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Minor grammar fix, correcting the phrase "Generate _an_ hash" to "Generate _a_ hash" in the checksum generator description. This correction is made in `en-US` and replicated across another 11 localisation files that have not yet been translated.

It is not always clear in English whether 'a' or 'an' should be used before an 'h' ([some discussion](https://english.stackexchange.com/questions/629/when-should-i-use-a-versus-an-in-front-of-a-word-beginning-with-the-letter-h)). However, this particular case is [not ambiguous](https://books.google.com/ngrams/graph?content=a+hash%2Can+hash). 😊

I did not create an issue for this PR as it is trivial.

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Internationalization and localization
- [ ] Other (please describe):

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass