### PR TITLE
Add splitter between Header & Paylod in JWT Decoder

### DIFF
--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolPage.xaml
@@ -5,6 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:DevToys.UI.Controls"
+    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
     mc:Ignorable="d"
     NavigationCacheMode="Required">
 
@@ -17,8 +18,9 @@
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition MinHeight="200"/>
+            <RowDefinition Height="16" />
+            <RowDefinition MinHeight="200"/>
         </Grid.RowDefinitions>
 
         <controls:CustomTextBox
@@ -36,9 +38,22 @@
             CodeLanguage="json"
             IsReadOnly="True"/>
 
+        <toolkit:GridSplitter
+            x:Name="PayloadGridSplitter"
+            Grid.Row="2"
+            Height="16"
+            ResizeBehavior="BasedOnAlignment"
+            ResizeDirection="Auto">
+            <toolkit:GridSplitter.Element>
+                <FontIcon
+                    Glyph="&#xFD52;"
+                    FontSize="13"/>
+            </toolkit:GridSplitter.Element>
+        </toolkit:GridSplitter>
+        
         <controls:CodeEditor
             x:Name="PayloadCodeEditor"
-            Grid.Row="2"
+            Grid.Row="3"
             Header="{x:Bind ViewModel.Strings.PayloadLabel}"
             Text="{x:Bind ViewModel.JwtPayload, Mode=OneWay}"
             CodeLanguage="json"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

The JWT Header is _generally_ much smaller than the Payload in comparison. Adding a splitter allows the user to adjust the size of the panels to focus on the panel that is most important to them.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current behavior treats both panels as equals which makes it harder to focus on the payload.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a new grid row between the Header & Payload rows to allow resizing

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [X] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Verified that the change work in Release build configuration
- [X] Checked all unit tests pass