### PR TITLE
JsonHelper.IsValid is not matching some JSON structures

### DIFF
--- a/src/dev/impl/DevToys/Helpers/JsonHelper.cs
+++ b/src/dev/impl/DevToys/Helpers/JsonHelper.cs
@@ -17,34 +17,26 @@ namespace DevToys.Helpers
         /// </summary>
         internal static bool IsValid(string? input)
         {
-            if (string.IsNullOrWhiteSpace(input))
+            input = input?.Trim();
+
+            if (input == null)
             {
+                return true;
+            }
+
+            try
+            {
+                var jtoken = JToken.Parse(input);
+                return jtoken is not null;
+            }
+            catch (JsonReaderException)
+            {
+                // Exception in parsing json. It likely mean the text isn't a JSON.
                 return false;
             }
-
-            input = input!.Trim();
-
-            if ((input.StartsWith("{") && input.EndsWith("}")) //For object
-                || (input.StartsWith("[") && input.EndsWith("]"))) //For array
+            catch (Exception ex) //some other exception
             {
-                try
-                {
-                    var jtoken = JToken.Parse(input);
-                    return jtoken is not null;
-                }
-                catch (JsonReaderException)
-                {
-                    // Exception in parsing json. It likely mean the text isn't a JSON.
-                    return false;
-                }
-                catch (Exception ex) //some other exception
-                {
-                    Logger.LogFault("Check is string if JSON", ex);
-                    return false;
-                }
-            }
-            else
-            {
+                Logger.LogFault("Check if string is JSON", ex);
                 return false;
             }
         }
@@ -54,14 +46,14 @@ namespace DevToys.Helpers
         /// </summary>
         internal static string Format(string? input, Indentation indentationMode)
         {
-            if (!IsValid(input))
+            if (input == null || !IsValid(input))
             {
                 return string.Empty;
             }
 
             try
             {
-                var jtoken = JToken.Parse(input!);
+                var jtoken = JToken.Parse(input);
                 if (jtoken is not null)
                 {
                     var stringBuilder = new StringBuilder();

--- a/src/tests/DevToys.Tests/Helpers/JsonHelperTests.cs
+++ b/src/tests/DevToys.Tests/Helpers/JsonHelperTests.cs
@@ -8,7 +8,9 @@ namespace DevToys.Tests.Helpers
     public class JsonHelperTests
     {
         [DataTestMethod]
-        [DataRow(null, false)]
+        [DataRow(null, true)]
+        [DataRow("\"foo\"", true)]
+        [DataRow("123", true)]
         [DataRow("", false)]
         [DataRow(" ", false)]
         [DataRow("   {  }  ", true)]


### PR DESCRIPTION
This PR corrects `JsonHelper.IsValid` and `JsonHelper.Format` to support some valid Json inputs like `"foo"`, `123`, and `null`

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?
Issue Number: https://github.com/veler/DevToys/issues/243

## What is the new behavior?
`JsonHelper.IsValid` now returns `true` for Json inputs like `"foo"`, `123`, and `null`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass