### PR TITLE
Fix for incorrect base64 hashes

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/HashGenerator/HashGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/HashGenerator/HashGeneratorToolViewModel.cs
@@ -190,21 +190,15 @@ namespace DevToys.ViewModels.Tools.HashGenerator
                 string? hash="";
                 if (string.Equals(OutputType, HexOutput))
                 {
-                    hash = CryptographicBuffer.EncodeToHexString(buffer);
+                    hash = IsUppercase
+                        ? CryptographicBuffer.EncodeToHexString(buffer).ToUpperInvariant()
+                        : CryptographicBuffer.EncodeToHexString(buffer).ToLowerInvariant();
                 }
                 else if (string.Equals(OutputType, Base64Output))
                 {
                     hash = CryptographicBuffer.EncodeToBase64String(buffer);
                 }
-
-                if (IsUppercase)
-                {
-                    return hash.ToUpperInvariant();
-                }
-                else
-                {
-                    return hash.ToLowerInvariant();
-                }
+                return hash;
             }
             catch (Exception ex)
             {

--- a/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml
@@ -24,6 +24,7 @@
                     <FontIcon Glyph="&#xF7B2;" />
                 </controls:ExpandableSettingControl.Icon>
                 <ToggleSwitch
+                    x:Name="IsUppercaseToggleSwitch"
                     Style="{StaticResource RightAlignedToggleSwitchStyle}"
                     IsOn="{x:Bind ViewModel.IsUppercase, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
             </controls:ExpandableSettingControl>
@@ -35,7 +36,8 @@
                 </controls:ExpandableSettingControl.Icon>
                 <ComboBox
                     SelectedValuePath="Tag"
-                    SelectedValue="{x:Bind ViewModel.OutputType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    SelectedValue="{x:Bind ViewModel.OutputType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    SelectionChanged="OutputType_SelectionChanged">
                     <ComboBoxItem Tag="Hex" Content="{x:Bind ViewModel.Strings.OutputHex}" />
                     <ComboBoxItem Tag="Base64" Content="{x:Bind ViewModel.Strings.OutputBase64}"/>
                 </ComboBox>

--- a/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml.cs
@@ -46,5 +46,17 @@ namespace DevToys.Views.Tools.HashGenerator
 
             base.OnNavigatedTo(e);
         }
+
+        private void OutputType_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if ((sender as ComboBox)?.SelectedValue as string == "Base64")
+            {
+                IsUppercaseToggleSwitch.IsEnabled = false;
+            }
+            else
+            {
+                IsUppercaseToggleSwitch.IsEnabled = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR disables the uppercase toggle switch if `Base64` is selected as the output type in the Hash Generator Tool.
Also refactors related if conditions in `HashGeneratorToolViewModel`

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/veler/DevToys/issues/395

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The uppercase toggle switch becomes disabled if `Base64` is selected as the output type.
Base64 outputs are no longer converted to lower/upper-case

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass