### PR TITLE
Trimmed input string for the JwtDecoderEncoder

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolProvider.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolProvider.cs
@@ -39,7 +39,7 @@ namespace DevToys.ViewModels.Tools.JwtDecoderEncoder
 
         public bool CanBeTreatedByTool(string data)
         {
-            return JwtHelper.IsValid(data);
+            return JwtHelper.IsValid(data?.Trim());
         }
 
         public IToolViewModel CreateTool()

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolViewModel.cs
@@ -40,7 +40,7 @@ namespace DevToys.ViewModels.Tools.JwtDecoderEncoder
             get => _jwtToken;
             set
             {
-                SetProperty(ref _jwtToken, value);
+                SetProperty(ref _jwtToken, value?.Trim());
                 QueueConversion();
             }
         }


### PR DESCRIPTION
## FIX

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?
Currently, if there is an empty space in the input for the JWT decoder, the decoding will fail.

Issue Number: #391

## What is the new behavior?
- With the fix, the input string gets trimmed, so that any empty spaces will be removed.

## Other information

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Verified that the change work in Release build configuration
- [X] Checked all unit tests pass