### PR TITLE
Fixed an error when the textbox of NumberBaseConverter is empty.

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseConverterToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Converters/NumberBaseConverter/NumberBaseConverterToolViewModel.cs
@@ -208,7 +208,13 @@ namespace DevToys.ViewModels.Tools.NumberBaseConverter
             }
 
             var input = (CustomTextBox)source;
-            switch(input.Tag)
+
+            if (input.Text.Length == 0)
+            {
+                return;
+            }
+
+            switch (input.Tag)
             {
                 case "Binary" when InputBaseNumber == NumberBaseFormat.Binary:
                     input.Text = NumberBaseFormatter.FormatNumber(input.Text, InputBaseNumber);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixed a bug in NumberBaseConverter that caused DevToys to quit when switching focus when the text box was empty.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass
