### PR TITLE
Fix textbox cut command

### DIFF
--- a/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
+++ b/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
@@ -139,7 +139,11 @@ namespace DevToys.UI.Controls
 
         private bool CanExecuteCutCommand()
         {
-            return RichEditBox != null && RichEditBox.TextDocument.Selection.Length != 0 && IsEnabled && RichEditBox.TextDocument.CanCopy();
+            return RichEditBox != null
+                   && RichEditBox.TextDocument.Selection.Length != 0
+                   && IsEnabled
+                   && RichEditBox.TextDocument.CanCopy()
+                   && IsReadOnly == false;
         }
 
         private void ExecuteCutCommand()

--- a/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
+++ b/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
@@ -140,10 +140,10 @@ namespace DevToys.UI.Controls
         private bool CanExecuteCutCommand()
         {
             return RichEditBox != null
+                   && !IsReadOnly
                    && RichEditBox.TextDocument.Selection.Length != 0
                    && IsEnabled
-                   && RichEditBox.TextDocument.CanCopy()
-                   && IsReadOnly == false;
+                   && RichEditBox.TextDocument.CanCopy();
         }
 
         private void ExecuteCutCommand()
@@ -207,7 +207,7 @@ namespace DevToys.UI.Controls
 
         private bool CanExecuteDeleteCommand()
         {
-            return RichEditBox != null && RichEditBox.TextDocument.Selection.Length != 0 && IsEnabled && !IsReadOnly;
+            return RichEditBox != null && !IsReadOnly && RichEditBox.TextDocument.Selection.Length != 0 && IsEnabled;
         }
 
         private void ExecuteDeleteCommand()

--- a/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
+++ b/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
@@ -653,6 +653,7 @@ namespace DevToys.UI.Controls
         private void TextBox_CuttingToClipboard(TextBox sender, TextControlCuttingToClipboardEventArgs args)
         {
             CopyTextBoxSelectionToClipboard();
+            sender.SelectedText = string.Empty;
             args.Handled = true;
         }
 
@@ -670,6 +671,7 @@ namespace DevToys.UI.Controls
         private void RichEditBox_CuttingToClipboard(RichEditBox sender, TextControlCuttingToClipboardEventArgs args)
         {
             CopyRichEditBoxSelectionToClipboard();
+            sender.TextDocument.Selection.Text = string.Empty;
             args.Handled = true;
         }
 

--- a/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
+++ b/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
@@ -139,10 +139,10 @@ namespace DevToys.UI.Controls
 
         private bool CanExecuteCutCommand()
         {
-            return RichEditBox != null
+            return IsEnabled
                    && !IsReadOnly
+                   && RichEditBox != null
                    && RichEditBox.TextDocument.Selection.Length != 0
-                   && IsEnabled
                    && RichEditBox.TextDocument.CanCopy();
         }
 
@@ -207,7 +207,10 @@ namespace DevToys.UI.Controls
 
         private bool CanExecuteDeleteCommand()
         {
-            return RichEditBox != null && !IsReadOnly && RichEditBox.TextDocument.Selection.Length != 0 && IsEnabled;
+            return  IsEnabled
+                    && !IsReadOnly
+                    && RichEditBox != null
+                    && RichEditBox.TextDocument.Selection.Length != 0;
         }
 
         private void ExecuteDeleteCommand()


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #448 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Disabled cut command for read-only textbox.
- Added post-processing for text cut command.

## Other information

Disabled cut command for read-only textbox.
This change eliminates access denied errors.
![image](https://user-images.githubusercontent.com/2970321/159143555-1b9cffdb-0dc9-4eea-ae88-e37ea379f034.png)

> Feature name: Failed to cut from custom text box
> Custom message: 
> Exception message: Access is denied. (Exception from HRESULT: 0x80070005)
> Exception stack trace:
>    at System.Runtime.InteropServices.McgMarshal.ThrowOnExternalCallFailed(Int32, RuntimeTypeHandle) + 0x21
>    at __Interop.ComCallHelpers.Call(__ComObject, RuntimeTypeHandle, Int32) + 0xb8
>    at __Interop.ForwardComStubs.Stub_17[TThis](__ComObject, Int32) + 0x24
>    at Windows.UI.Text.ITextRange__Impl.Dispatcher.global::Windows.UI.Text.ITextRange.Cut() + 0x18
>    at DevToys.UI.Controls.CustomTextBox.ExecuteCutCommand() + 0x3b


<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass
