### PR TITLE
Update Korean translation "ko-KR"

### DIFF
--- a/src/dev/impl/DevToys/Strings/ko-KR/Base64EncoderDecoder.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/Base64EncoderDecoder.resw
@@ -130,7 +130,7 @@
     <value>디코드</value>
   </data>
   <data name="ConversionDescription" xml:space="preserve">
-    <value>사용할 변환 작업 선택합니다.</value>
+    <value>사용할 변환 방법을 선택합니다.</value>
   </data>
   <data name="ConversionEncode" xml:space="preserve">
     <value>인코드</value>
@@ -142,7 +142,7 @@
     <value>Base 64</value>
   </data>
   <data name="EncodingDescription" xml:space="preserve">
-    <value>사용할 변환 작업을 선택합니다.</value>
+    <value>사용할 인코딩을 선택합니다.</value>
   </data>
   <data name="EncodingTitle" xml:space="preserve">
     <value>인코딩</value>

--- a/src/dev/impl/DevToys/Strings/ko-KR/CheckSumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/CheckSumGenerator.resw
@@ -157,9 +157,9 @@
     <value>Checksum</value>
   </data>
   <data name="HashesMatch" xml:space="preserve">
-    <value>The hashes are the same.</value>
+    <value>해시가 서로 일치합니다.</value>
   </data>
   <data name="HashesMismatch" xml:space="preserve">
-    <value>The hashes are different.</value>
+    <value>해시가 서로 일치하지 않습니다.</value>
   </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/ko-KR/Common.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/Common.resw
@@ -139,7 +139,7 @@
     <value>폴더 선택</value>
   </data>
   <data name="FileSelectorDragDropAnyFile" xml:space="preserve">
-    <value>여기에 파일을 드래그 하세요.</value>
+    <value>여기에 파일을 드래그 하세요</value>
   </data>
   <data name="FileSelectorDragDropAnyFiles" xml:space="preserve">
     <value>여기에 파일들을 드래그 하세요</value>
@@ -149,7 +149,7 @@
     <comment>{0} is a single file extension like "PNG"</comment>
   </data>
   <data name="FileSelectorDragDropAnySpecificFiles" xml:space="preserve">
-    <value>여기에 {0} 파일들을 드래그 하세요.</value>
+    <value>여기에 {0} 파일들을 드래그 하세요</value>
     <comment>{0} is a list of file extensions like "PNG, TXT, JPG"</comment>
   </data>
   <data name="FileSelectorInvalidSelectedFiles" xml:space="preserve">
@@ -181,7 +181,7 @@
     <value>수행 재개</value>
   </data>
   <data name="Refresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>새로고침</value>
   </data>
   <data name="SelectAll" xml:space="preserve">
     <value>모두 선택</value>
@@ -196,7 +196,7 @@
     <value>켜기</value>
   </data>
   <data name="UnableOpenFile" xml:space="preserve">
-    <value>파일을 열기 실패</value>
+    <value>파일을 열 수 없습니다</value>
   </data>
   <data name="UnableOpenFileDescription" xml:space="preserve">
     <value>'{0}' 파일을 열 수 없습니다. 로그를 확인하여 자세한 원인을 확인할 수 있습니다.</value>

--- a/src/dev/impl/DevToys/Strings/ko-KR/ImageConverter.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/ImageConverter.resw
@@ -152,7 +152,7 @@
     <value>다른 이름으로 저장</value>
   </data>
   <data name="SeeErrorMessage" xml:space="preserve">
-    <value>상세 보기</value>
+    <value>자세히 보기</value>
   </data>
   <data name="Description" xml:space="preserve">
     <value>무손실 이미지 변환기</value>

--- a/src/dev/impl/DevToys/Strings/ko-KR/JwtDecoderEncoder.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/JwtDecoderEncoder.resw
@@ -124,7 +124,7 @@
     <value>설정</value>
   </data>
   <data name="ConversionDescription" xml:space="preserve">
-    <value>사용할 작업을 선택하세요.</value>
+    <value>사용할 작업을 선택합니다.</value>
   </data>
   <data name="ConversionTitle" xml:space="preserve">
     <value>작업</value>

--- a/src/dev/impl/DevToys/Strings/ko-KR/LoremIpsumGenerator.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/LoremIpsumGenerator.resw
@@ -148,7 +148,7 @@
     <value>문장</value>
   </data>
   <data name="StartWithLoremTitle" xml:space="preserve">
-    <value>Start with 'Lorem ipsum dolor sit amet...'</value>
+    <value>'Lorem ipsum dolor sit amet...' 문구 사용</value>
   </data>
   <data name="TypeDescription" xml:space="preserve">
     <value>로렌 입숨 내용을 생성할 단어, 문장 및 문단 개수를 선택 후 생성합니다.</value>

--- a/src/dev/impl/DevToys/Strings/ko-KR/MainPage.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/MainPage.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AddToFavorites" xml:space="preserve">
-    <value>Add to favorites</value>
+    <value>즐겨찾기에 추가</value>
   </data>
   <data name="EnterCompactOverlayTooltip" xml:space="preserve">
     <value>항상 위로 (Ctrl+Up)</value>
@@ -146,25 +146,25 @@
     <value>지금 업데이트...</value>
   </data>
   <data name="NotificationUpdateAvailableTitle" xml:space="preserve">
-    <value>새 업데이트가 도착했습니다! 🚀</value>
+    <value>새 업데이트가 있습니다! 🚀</value>
   </data>
   <data name="OpenInNewWindow" xml:space="preserve">
     <value>새 창으로 열기</value>
   </data>
   <data name="PinToolToStart" xml:space="preserve">
-    <value>도구를 찍어 시작합니다.</value>
+    <value>시작 메뉴에 도구 추가하기</value>
   </data>
   <data name="PinToolToStartProblem" xml:space="preserve">
     <value>도구를 찍어 시작할 수 없습니다. 로그를 통해 자세한 내용을 보실 수 있습니다.</value>
   </data>
   <data name="RemoveFromFavorites" xml:space="preserve">
-    <value>Remove from favorites</value>
+    <value>즐겨찾기에서 제거</value>
   </data>
   <data name="Search" xml:space="preserve">
     <value>도구명을 입력하여 검색...</value>
   </data>
   <data name="SearchNoResultsFound" xml:space="preserve">
-    <value>검색한 도구가 없습니다.</value>
+    <value>검색된 도구가 없습니다.</value>
   </data>
   <data name="WindowTitle" xml:space="preserve">
     <value>DevToys</value>

--- a/src/dev/impl/DevToys/Strings/ko-KR/MarkdownPreview.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/MarkdownPreview.resw
@@ -142,7 +142,7 @@
     <value>테마</value>
   </data>
   <data name="ThemeDescription" xml:space="preserve">
-    <value>마크다운을 미리볼 때에 대한 테마를 선택합니다.</value>
+    <value>마크다운 미리보기 테마를 선택합니다.</value>
   </data>
   <data name="Description" xml:space="preserve">
     <value>Github 방식으로 마크다운 문서를 미리볼 수 있습니다.</value>

--- a/src/dev/impl/DevToys/Strings/ko-KR/NumberBaseConverter.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/NumberBaseConverter.resw
@@ -179,25 +179,25 @@
   <data name="SearchKeywords" xml:space="preserve">
     <value>Binary Octal Decimal Hexadecimal</value>
   </data>
-    <data name="AdvancedModeLabel" xml:space="preserve">
-    <value>Advanced mode</value>
+  <data name="AdvancedModeLabel" xml:space="preserve">
+    <value>고급 모드</value>
   </data>
   <data name="InputDictionaryLabel" xml:space="preserve">
-    <value>Input dictionary</value>
+    <value>딕셔너리 입력</value>
   </data>
   <data name="OutputDictionaryLabel" xml:space="preserve">
-    <value>Output dictionary</value>
+    <value>딕셔너리 출력</value>
   </data>
   <data name="Output" xml:space="preserve">
-    <value>Output</value>
+    <value>출력 내용</value>
   </data>
   <data name="BaseNumberError" xml:space="preserve">
-    <value>Base number should be greater than 1.</value>
+    <value>기수는 1보다 커야 합니다.</value>
   </data>
   <data name="DictionarySizeError" xml:space="preserve">
-    <value>Dictionary size should be greater than 1.</value>
+    <value>딕셔너리 크기는 1보다 커야 합니다.</value>
   </data>
   <data name="IncompatibleBaseDictionaryError" xml:space="preserve">
-    <value>Dictionary size could not be smaller than the base number.</value>
+    <value>딕셔너리 크기는 기수보다 작을 수 없습니다.</value>
   </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/ko-KR/StringEscapeUnescape.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/StringEscapeUnescape.resw
@@ -118,40 +118,40 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AccessibleName" xml:space="preserve">
-    <value>Text Escape and Unescape tool</value>
+    <value>텍스트 이스케이프 및 이스케이프 해제 도구</value>
   </data>
   <data name="MenuDisplayName" xml:space="preserve">
-    <value>Escape / Unescape</value>
+    <value>이스케이프 / 이스케이프 해제</value>
   </data>
   <data name="OutputTitle" xml:space="preserve">
-    <value>Output</value>
+    <value>출력 내용</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Escapes or unescapes a string, removing characters that could prevent parsing.</value>
+    <value>문자열을 이스케이프 하거나 해제해 파싱을 방해할 수 있는 문자를 제거합니다.</value>
   </data>
   <data name="SearchDisplayName" xml:space="preserve">
-    <value>Text Escape / Unescape</value>
+    <value>텍스트 이스케이프 / 이스케이프 해제</value>
   </data>
   <data name="SearchKeywords" xml:space="preserve">
     <value />
     <comment>Alternative search keywords. Enables searching for words that are not included in Description, MenuDisplayName, and SearchDisplayName.</comment>
   </data>
   <data name="ConfigurationTitle" xml:space="preserve">
-    <value>Configuration</value>
+    <value>설정</value>
   </data>
   <data name="ConversionDecode" xml:space="preserve">
-    <value>Unescape</value>
+    <value>이스케이프 해제</value>
   </data>
   <data name="ConversionDescription" xml:space="preserve">
-    <value>Select which conversion mode you want to use</value>
+    <value>사용할 변환 방법을 선택합니다.</value>
   </data>
   <data name="ConversionEncode" xml:space="preserve">
-    <value>Escape</value>
+    <value>이스케이프</value>
   </data>
   <data name="ConversionTitle" xml:space="preserve">
-    <value>Conversion</value>
+    <value>변환</value>
   </data>
   <data name="InputTitle" xml:space="preserve">
-    <value>Input</value>
+    <value>입력 내용</value>
   </data>
 </root>

--- a/src/dev/impl/DevToys/Strings/ko-KR/Timestamp.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/Timestamp.resw
@@ -118,49 +118,49 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AccessibleName" xml:space="preserve">
-    <value>Timestamp converter tool</value>
+    <value>타임스탬프 변환기</value>
   </data>
   <data name="DayTitle" xml:space="preserve">
-    <value>Day</value>
+    <value>일</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Convert timestamp to human-readable date and vice versa</value>
+    <value>타임스탬프를 읽기 쉬운 날짜로 변환하거나 반대로 변환합니다.</value>
   </data>
   <data name="HourTitle" xml:space="preserve">
-    <value>Hour (24 hour)</value>
+    <value>시 (24 시간제)</value>
   </data>
   <data name="InvalidValue" xml:space="preserve">
-    <value>Invalid value</value>
+    <value>잘못된 값</value>
   </data>
   <data name="LocalDateTime" xml:space="preserve">
-    <value>Local Date and Time</value>
+    <value>현지 날짜 및 시간</value>
   </data>
   <data name="MenuDisplayName" xml:space="preserve">
-    <value>Timestamp</value>
+    <value>타임스탬프</value>
   </data>
   <data name="MinutesTitle" xml:space="preserve">
-    <value>Minutes</value>
+    <value>분</value>
   </data>
   <data name="MonthTitle" xml:space="preserve">
-    <value>Month</value>
+    <value>월</value>
   </data>
   <data name="SearchDisplayName" xml:space="preserve">
-    <value>Unix Timestamp Converter</value>
+    <value>Unix 타임스탬프 변환기</value>
   </data>
   <data name="SearchKeywords" xml:space="preserve">
     <value>Time Date Timezone Epoch</value>
     <comment>Alternative search keywords. Enables searching for words that are not included in Description, MenuDisplayName, and SearchDisplayName.</comment>
   </data>
   <data name="SecondsTitle" xml:space="preserve">
-    <value>Seconds</value>
+    <value>초</value>
   </data>
   <data name="TimestampTitle" xml:space="preserve">
-    <value>Timestamp</value>
+    <value>타임스탬프</value>
   </data>
   <data name="UTCDateTime" xml:space="preserve">
-    <value>UTC Date and Time</value>
+    <value>UTC 날짜 및 시간</value>
   </data>
   <data name="YearTitle" xml:space="preserve">
-    <value>Year</value>
+    <value>년</value>
   </data>
 </root>


### PR DESCRIPTION
Add Korean translations for Number base converter, String escape and unescape tool and Timestamp converter tool.
Also, I translated not yet translated things in other tools and update some expressions.
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Update Korean translation (ko-KR)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass
