### PR TITLE
#483 Added Now button to bring timestamp to current date and time.

### DIFF
--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -605,6 +605,11 @@ namespace DevToys
         public string Megabytes => _resources.GetString("Megabytes");
 
         /// <summary>
+        /// Gets the resource Now.
+        /// </summary>
+        public string Now => _resources.GetString("Now");
+
+        /// <summary>
         /// Gets the resource Ok.
         /// </summary>
         public string Ok => _resources.GetString("Ok");

--- a/src/dev/impl/DevToys/Strings/cs-CZ/Common.resw
+++ b/src/dev/impl/DevToys/Strings/cs-CZ/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Nyní</value>
+  </data>
   <data name="OpenFile" xml:space="preserve">
     <value>Načíst soubor</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/cs-CZ/Common.resw
+++ b/src/dev/impl/DevToys/Strings/cs-CZ/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Nyní</value>
+    <value>Now</value>
   </data>
   <data name="OpenFile" xml:space="preserve">
     <value>Načíst soubor</value>

--- a/src/dev/impl/DevToys/Strings/de-DE/Common.resw
+++ b/src/dev/impl/DevToys/Strings/de-DE/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Jetzt</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/dev/impl/DevToys/Strings/de-DE/Common.resw
+++ b/src/dev/impl/DevToys/Strings/de-DE/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Jetzt</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/en-US/Common.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Now</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/es-AR/Common.resw
+++ b/src/dev/impl/DevToys/Strings/es-AR/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Ahora</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/es-AR/Common.resw
+++ b/src/dev/impl/DevToys/Strings/es-AR/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Ahora</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/dev/impl/DevToys/Strings/es-ES/Common.resw
+++ b/src/dev/impl/DevToys/Strings/es-ES/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Ahora</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/es-ES/Common.resw
+++ b/src/dev/impl/DevToys/Strings/es-ES/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Ahora</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/dev/impl/DevToys/Strings/fr-FR/Common.resw
+++ b/src/dev/impl/DevToys/Strings/fr-FR/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MO</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>À présent</value>
+  </data>
   <data name="OpenFile" xml:space="preserve">
     <value>Ouvrir un fichier</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/fr-FR/Common.resw
+++ b/src/dev/impl/DevToys/Strings/fr-FR/Common.resw
@@ -169,7 +169,7 @@
     <value>MO</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>À présent</value>
+    <value>Now</value>
   </data>
   <data name="OpenFile" xml:space="preserve">
     <value>Ouvrir un fichier</value>

--- a/src/dev/impl/DevToys/Strings/hu-HU/Common.resw
+++ b/src/dev/impl/DevToys/Strings/hu-HU/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Most</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/hu-HU/Common.resw
+++ b/src/dev/impl/DevToys/Strings/hu-HU/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Most</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/dev/impl/DevToys/Strings/id-ID/Common.resw
+++ b/src/dev/impl/DevToys/Strings/id-ID/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Sekarang</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/id-ID/Common.resw
+++ b/src/dev/impl/DevToys/Strings/id-ID/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Sekarang</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/dev/impl/DevToys/Strings/it-IT/Common.resw
+++ b/src/dev/impl/DevToys/Strings/it-IT/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Adesso</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/it-IT/Common.resw
+++ b/src/dev/impl/DevToys/Strings/it-IT/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Adesso</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/dev/impl/DevToys/Strings/ja-JP/Common.resw
+++ b/src/dev/impl/DevToys/Strings/ja-JP/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>今</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/dev/impl/DevToys/Strings/ja-JP/Common.resw
+++ b/src/dev/impl/DevToys/Strings/ja-JP/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>今</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/ko-KR/Common.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>지금</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>확인</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/ko-KR/Common.resw
+++ b/src/dev/impl/DevToys/Strings/ko-KR/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>지금</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>확인</value>

--- a/src/dev/impl/DevToys/Strings/pl-PL/Common.resw
+++ b/src/dev/impl/DevToys/Strings/pl-PL/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Teraz</value>
+  </data>
   <data name="OpenFile" xml:space="preserve">
     <value>Wczyaj plik</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/pl-PL/Common.resw
+++ b/src/dev/impl/DevToys/Strings/pl-PL/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Teraz</value>
+    <value>Now</value>
   </data>
   <data name="OpenFile" xml:space="preserve">
     <value>Wczyaj plik</value>

--- a/src/dev/impl/DevToys/Strings/pt-BR/Common.resw
+++ b/src/dev/impl/DevToys/Strings/pt-BR/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Agora</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/dev/impl/DevToys/Strings/pt-BR/Common.resw
+++ b/src/dev/impl/DevToys/Strings/pt-BR/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Agora</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/pt-PT/Common.resw
+++ b/src/dev/impl/DevToys/Strings/pt-PT/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Agora</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/dev/impl/DevToys/Strings/pt-PT/Common.resw
+++ b/src/dev/impl/DevToys/Strings/pt-PT/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Agora</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/ru-RU/Common.resw
+++ b/src/dev/impl/DevToys/Strings/ru-RU/Common.resw
@@ -169,7 +169,7 @@
     <value>МБ</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>Теперь</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>ОК</value>

--- a/src/dev/impl/DevToys/Strings/ru-RU/Common.resw
+++ b/src/dev/impl/DevToys/Strings/ru-RU/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>МБ</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>Теперь</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>ОК</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/zh-Hans/Common.resw
+++ b/src/dev/impl/DevToys/Strings/zh-Hans/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>现在</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>确定</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/zh-Hans/Common.resw
+++ b/src/dev/impl/DevToys/Strings/zh-Hans/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>现在</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>确定</value>

--- a/src/dev/impl/DevToys/Strings/zh-Hant/Common.resw
+++ b/src/dev/impl/DevToys/Strings/zh-Hant/Common.resw
@@ -169,7 +169,7 @@
     <value>MB</value>
   </data>
   <data name="Now" xml:space="preserve">
-    <value>现在</value>
+    <value>Now</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>確定</value>

--- a/src/dev/impl/DevToys/Strings/zh-Hant/Common.resw
+++ b/src/dev/impl/DevToys/Strings/zh-Hant/Common.resw
@@ -168,6 +168,9 @@
   <data name="Megabytes" xml:space="preserve">
     <value>MB</value>
   </data>
+  <data name="Now" xml:space="preserve">
+    <value>现在</value>
+  </data>
   <data name="Ok" xml:space="preserve">
     <value>確定</value>
   </data>

--- a/src/dev/impl/DevToys/ViewModels/Tools/Converters/Timestamp/TimestampToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Converters/Timestamp/TimestampToolViewModel.cs
@@ -304,6 +304,7 @@ namespace DevToys.ViewModels.Tools.Timestamp
         {
             PasteCommand = new RelayCommand(ExecutePasteCommand);
             CopyCommand = new RelayCommand(ExecuteCopyCommand);
+            NowCommand = new RelayCommand(ExecuteNowCommand);
 
             // Set to the current epoch time.
             Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
@@ -359,6 +360,18 @@ namespace DevToys.ViewModels.Tools.Timestamp
             {
                 Core.Logger.LogFault("Failed to copy from numeric box", ex);
             }
+        }
+
+        #endregion
+
+        #region NowCommand
+        internal IRelayCommand NowCommand { get; }
+
+        private void ExecuteNowCommand()
+        {
+            Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            ResetUtcDateTime();
+            ResetLocalDateTime();
         }
 
         #endregion

--- a/src/dev/impl/DevToys/Views/Tools/Converters/Timestamp/TimestampToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Converters/Timestamp/TimestampToolPage.xaml
@@ -46,6 +46,14 @@
                     AutomationProperties.LabeledBy="{Binding ElementName=TimestampHeaderTextBlock}">
                     <Button
                         TabIndex="1"
+                        Command="{x:Bind ViewModel.NowCommand}"
+                        AutomationProperties.Name="{Binding Instance.Common.Now, Mode=OneTime, Source={StaticResource LanguageManager}}">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <TextBlock VerticalAlignment="Center" Text="{Binding Instance.Common.Now, Mode=OneTime, Source={StaticResource LanguageManager}}"/>
+                        </StackPanel>
+                    </Button>
+                    <Button
+                        TabIndex="2"
                         Command="{x:Bind ViewModel.PasteCommand}"
                         AutomationProperties.Name="{Binding Instance.Common.Paste, Mode=OneTime, Source={StaticResource LanguageManager}}">
                         <StackPanel Orientation="Horizontal" Spacing="4">
@@ -54,7 +62,7 @@
                         </StackPanel>
                     </Button>
                     <Button
-                        TabIndex="2"
+                        TabIndex="3"
                         Command="{x:Bind ViewModel.CopyCommand}"
                         AutomationProperties.Name="{Binding Instance.Common.Copy, Mode=OneTime, Source={StaticResource LanguageManager}}">
                         <StackPanel Orientation="Horizontal" Spacing="4">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [x] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Introduces request from #483 which asks to have a Now button. The button could also be labeled "Reset", but the term "Now" is more explicit about what the button intends to do (set all times to the current date and time).

Issue Number: #483 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a "Now" button in the Timestamp converter
- Clicking the "Now" button sets time to currnet date and time and resets the display window times
- Behaves similar to how the page is initiated
- Added default transactions for "Now" button

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

![image](https://user-images.githubusercontent.com/17285914/167278713-8fc0be21-f16c-4fb2-a648-ae0ca1a0b1df.png)


## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass
