### PR TITLE
Apply the font set in settings to certain output text boxes

### DIFF
--- a/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml
+++ b/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml
@@ -134,7 +134,7 @@
                 SelectionChanged="TextBox_SelectionChanged"
                 CopyingToClipboard="TextBox_CopyingToClipboard"
                 CuttingToClipboard="TextBox_CuttingToClipboard"
-                AutomationProperties.LabeledBy="{Binding ElementName=HeaderTextBlock}"/>
+                AutomationProperties.LabeledBy="{Binding ElementName=HeaderTextBlock}" Loading="TextBox_Loading" />
             <RichEditBox
                 x:Name="RichEditBox"
                 x:Load="{x:Bind IsRichTextEdit}"

--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/GuidGenerator/GuidGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/GuidGenerator/GuidGeneratorToolViewModel.cs
@@ -69,7 +69,7 @@ namespace DevToys.ViewModels.Tools.GuidGenerator
         internal const string VersionOne = "One";
 
         private readonly IMarketingService _marketingService;
-        private readonly ISettingsProvider _settingsProvider;
+        internal ISettingsProvider SettingsProvider { get; }
 
         private string _output = string.Empty;
         private bool _toolSuccessfullyWorked;
@@ -80,12 +80,12 @@ namespace DevToys.ViewModels.Tools.GuidGenerator
 
         internal bool IsUppercase
         {
-            get => _settingsProvider.GetSetting(Uppercase);
+            get => SettingsProvider.GetSetting(Uppercase);
             set
             {
-                if (_settingsProvider.GetSetting(Uppercase) != value)
+                if (SettingsProvider.GetSetting(Uppercase) != value)
                 {
-                    _settingsProvider.SetSetting(Uppercase, value);
+                    SettingsProvider.SetSetting(Uppercase, value);
                     OnPropertyChanged();
                 }
             }
@@ -93,12 +93,12 @@ namespace DevToys.ViewModels.Tools.GuidGenerator
 
         internal bool IncludeHyphens
         {
-            get => _settingsProvider.GetSetting(Hyphens);
+            get => SettingsProvider.GetSetting(Hyphens);
             set
             {
-                if (_settingsProvider.GetSetting(Hyphens) != value)
+                if (SettingsProvider.GetSetting(Hyphens) != value)
                 {
-                    _settingsProvider.SetSetting(Hyphens, value);
+                    SettingsProvider.SetSetting(Hyphens, value);
                     OnPropertyChanged();
                 }
             }
@@ -106,12 +106,12 @@ namespace DevToys.ViewModels.Tools.GuidGenerator
 
         internal string UuidVersion
         {
-            get => _settingsProvider.GetSetting(Version);
+            get => SettingsProvider.GetSetting(Version);
             set
             {
-                if (_settingsProvider.GetSetting(Version) != value)
+                if (SettingsProvider.GetSetting(Version) != value)
                 {
-                    _settingsProvider.SetSetting(Version, value);
+                    SettingsProvider.SetSetting(Version, value);
                     OnPropertyChanged();
                 }
             }
@@ -119,12 +119,12 @@ namespace DevToys.ViewModels.Tools.GuidGenerator
 
         internal int NumberOfGuidsToGenerate
         {
-            get => _settingsProvider.GetSetting(GuidsToGenerate);
+            get => SettingsProvider.GetSetting(GuidsToGenerate);
             set
             {
-                if (_settingsProvider.GetSetting(GuidsToGenerate) != value)
+                if (SettingsProvider.GetSetting(GuidsToGenerate) != value)
                 {
-                    _settingsProvider.SetSetting(GuidsToGenerate, value);
+                    SettingsProvider.SetSetting(GuidsToGenerate, value);
                     OnPropertyChanged();
                 }
             }
@@ -141,7 +141,7 @@ namespace DevToys.ViewModels.Tools.GuidGenerator
         [ImportingConstructor]
         public GuidGeneratorToolViewModel(ISettingsProvider settingsProvider, IMarketingService marketingService)
         {
-            _settingsProvider = settingsProvider;
+            SettingsProvider = settingsProvider;
             _marketingService = marketingService;
 
             GenerateCommand = new RelayCommand(ExecuteGenerateCommand);

--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/HashGenerator/HashGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/HashGenerator/HashGeneratorToolViewModel.cs
@@ -38,7 +38,8 @@ namespace DevToys.ViewModels.Tools.HashGenerator
                 defaultValue: DefaultOutputType);
 
         private readonly IMarketingService _marketingService;
-        private readonly ISettingsProvider _settingsProvider;
+
+        internal ISettingsProvider SettingsProvider;
 
         private bool _toolSuccessfullyWorked;
         private string? _input;
@@ -56,12 +57,12 @@ namespace DevToys.ViewModels.Tools.HashGenerator
 
         internal bool IsUppercase
         {
-            get => _settingsProvider.GetSetting(Uppercase);
+            get => SettingsProvider.GetSetting(Uppercase);
             set
             {
-                if (_settingsProvider.GetSetting(Uppercase) != value)
+                if (SettingsProvider.GetSetting(Uppercase) != value)
                 {
-                    _settingsProvider.SetSetting(Uppercase, value);
+                    SettingsProvider.SetSetting(Uppercase, value);
                     OnPropertyChanged();
                     QueueHashCalculation();
                 }
@@ -70,12 +71,12 @@ namespace DevToys.ViewModels.Tools.HashGenerator
 
         internal string OutputType
         {
-            get => _settingsProvider.GetSetting(OutType);
+            get => SettingsProvider.GetSetting(OutType);
             set
             {
-                if (_settingsProvider.GetSetting(OutType) != value)
+                if (SettingsProvider.GetSetting(OutType) != value)
                 {
-                    _settingsProvider.SetSetting(OutType, value);
+                    SettingsProvider.SetSetting(OutType, value);
                     OnPropertyChanged();
                     QueueHashCalculation();
                 }
@@ -119,7 +120,7 @@ namespace DevToys.ViewModels.Tools.HashGenerator
         [ImportingConstructor]
         public HashGeneratorToolViewModel(ISettingsProvider settingsProvider, IMarketingService marketingService)
         {
-            _settingsProvider = settingsProvider;
+            SettingsProvider = settingsProvider;
             _marketingService = marketingService;
         }
 

--- a/src/dev/impl/DevToys/Views/Tools/Generators/GuidGenerator/GuidGeneratorToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Generators/GuidGenerator/GuidGeneratorToolPage.xaml
@@ -112,6 +112,7 @@
             AcceptsReturn="True"
             IsReadOnly="True"
             CanClearWhenReadOnly="True"
+            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.Output, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml
@@ -53,21 +53,25 @@
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.MD5}"
             IsReadOnly="True"
+            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.MD5, Mode=OneWay}"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.SHA1}"
             IsReadOnly="True"
+            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.SHA1, Mode=OneWay}"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.SHA256}"
             IsReadOnly="True"
+            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.SHA256, Mode=OneWay}"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.SHA512}"
             IsReadOnly="True"
+            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.SHA512, Mode=OneWay}"/>
     </StackPanel>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Text/RegEx/RegExToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/RegEx/RegExToolPage.xaml
@@ -101,6 +101,7 @@
         <controls:CustomTextBox
             Grid.Row="1"
             Header="{x:Bind ViewModel.Strings.RegularExpression}"
+            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.RegularExpression, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
         <controls:CustomTextBox
@@ -110,6 +111,7 @@
             AcceptsReturn="True"
             IsRichTextEdit="True"
             MinHeight="150"
+            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </Page>


### PR DESCRIPTION
Allows the selected font in the settings to be applied to areas that makes sense, for example selecting a fixed width font would make the output content easier to read. 

The following tools have this applied:

- The UUID Generator output
- The Hash Generator hash outputs
- Regex tester - regex string textbox

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [x] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Currently the output textbox uses the default Windows font (Segoe UI) which not a fixed width font. It is not currently possible to change this font during application use.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Numbers: #153 & #290 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `CustomTextBox` now takes note of the Font setting via the `SettingsProvider`. This allows various controls to inherit and bind to this setting.

## Other information

Screenshot showing the default font Segoe UI which cannot be changed by the settings
<img width="633" alt="image" src="https://user-images.githubusercontent.com/24935514/169660465-e7ceafc5-9da6-4aee-ba35-5ee23f3e6ffe.png">


Screenshot showing the applied font (Cascadia Mono)
<img width="620" alt="image" src="https://user-images.githubusercontent.com/24935514/169660417-639b56a3-4e61-4bd7-b48d-3773110703ca.png">

Screenshot showing that the font could also be changed to another fixed width font (Consolas in this case)
<img width="628" alt="image" src="https://user-images.githubusercontent.com/24935514/169660447-feda34a7-5844-4c65-93b9-1e33f6dd8fcd.png">


<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass
