### PR TITLE
Fixed Json Formatter altering date's time zone.

### DIFF
--- a/src/dev/impl/DevToys/Helpers/JsonYaml/JsonHelper.cs
+++ b/src/dev/impl/DevToys/Helpers/JsonYaml/JsonHelper.cs
@@ -61,40 +61,57 @@ namespace DevToys.Helpers.JsonYaml
 
             try
             {
-                var jtoken = JToken.Parse(input);
-                if (jtoken is not null)
+                var jsonLoadSettings = new JsonLoadSettings()
                 {
-                    var stringBuilder = new StringBuilder();
-                    using (var stringWriter = new StringWriter(stringBuilder))
-                    using (var jsonTextWriter = new JsonTextWriter(stringWriter))
-                    {
-                        switch (indentationMode)
-                        {
-                            case Indentation.TwoSpaces:
-                                jsonTextWriter.Formatting = Formatting.Indented;
-                                jsonTextWriter.IndentChar = ' ';
-                                jsonTextWriter.Indentation = 2;
-                                break;
-                            case Indentation.FourSpaces:
-                                jsonTextWriter.Formatting = Formatting.Indented;
-                                jsonTextWriter.IndentChar = ' ';
-                                jsonTextWriter.Indentation = 4;
-                                break;
-                            case Indentation.OneTab:
-                                jsonTextWriter.Formatting = Formatting.Indented;
-                                jsonTextWriter.IndentChar = '\t';
-                                jsonTextWriter.Indentation = 1;
-                                break;
-                            case Indentation.Minified:
-                                jsonTextWriter.Formatting = Formatting.None;
-                                break;
-                            default:
-                                throw new NotSupportedException();
-                        }
-                        jtoken.WriteTo(jsonTextWriter);
-                    }
+                    CommentHandling = CommentHandling.Ignore,
+                    DuplicatePropertyNameHandling = DuplicatePropertyNameHandling.Ignore,
+                    LineInfoHandling = LineInfoHandling.Load
+                };
 
-                    return stringBuilder.ToString();
+                using (var jsonReader = new JsonTextReader(new StringReader(input)))
+                {
+                    jsonReader.DateParseHandling = DateParseHandling.None;
+                    jsonReader.DateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
+
+                    var jtoken = JToken.ReadFrom(jsonReader, jsonLoadSettings);
+                    if (jtoken is not null)
+                    {
+                        var stringBuilder = new StringBuilder();
+                        using (var stringWriter = new StringWriter(stringBuilder))
+                        using (var jsonTextWriter = new JsonTextWriter(stringWriter))
+                        {
+                            switch (indentationMode)
+                            {
+                                case Indentation.TwoSpaces:
+                                    jsonTextWriter.Formatting = Formatting.Indented;
+                                    jsonTextWriter.IndentChar = ' ';
+                                    jsonTextWriter.Indentation = 2;
+                                    break;
+                                case Indentation.FourSpaces:
+                                    jsonTextWriter.Formatting = Formatting.Indented;
+                                    jsonTextWriter.IndentChar = ' ';
+                                    jsonTextWriter.Indentation = 4;
+                                    break;
+                                case Indentation.OneTab:
+                                    jsonTextWriter.Formatting = Formatting.Indented;
+                                    jsonTextWriter.IndentChar = '\t';
+                                    jsonTextWriter.Indentation = 1;
+                                    break;
+                                case Indentation.Minified:
+                                    jsonTextWriter.Formatting = Formatting.None;
+                                    break;
+                                default:
+                                    throw new NotSupportedException();
+                            }
+
+                            jsonTextWriter.DateFormatHandling = DateFormatHandling.IsoDateFormat;
+                            jsonTextWriter.DateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
+
+                            jtoken.WriteTo(jsonTextWriter);
+                        }
+
+                        return stringBuilder.ToString();
+                    }
                 }
 
                 return string.Empty;

--- a/src/tests/DevToys.Tests/Helpers/JsonHelperTests.cs
+++ b/src/tests/DevToys.Tests/Helpers/JsonHelperTests.cs
@@ -66,6 +66,13 @@ namespace DevToys.Tests.Helpers
         }
 
         [DataTestMethod]
+        [DataRow("{ \"Date\": \"2012-04-21T18:25:43-05:00\" }", "{\"Date\":\"2012-04-21T18:25:43-05:00\"}")]
+        public void FormatDoesNotAlterateDateTimes(string input, string expectedResult)
+        {
+            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.Minified));
+        }
+
+        [DataTestMethod]
         [DataRow(null, "")]
         [DataRow("", "")]
         [DataRow(" ", "")]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #573

## What is the new behavior?

Date time are now unchanged when parsing a JSON for formatting it.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [ ] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [X] Checked all unit tests pass
