### PR TITLE
JSON Formatter can now sort properties alphabetically.

### DIFF
--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -1359,6 +1359,11 @@ namespace DevToys
         /// Gets the resource SearchKeywords.
         /// </summary>
         public string SearchKeywords => _resources.GetString("SearchKeywords");
+
+        /// <summary>
+        /// Gets the resource SortProperties.
+        /// </summary>
+        public string SortProperties => _resources.GetString("SortProperties");
     }
 
     public class JsonYamlStrings : ObservableObject

--- a/src/dev/impl/DevToys/Strings/en-US/JsonFormatter.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/JsonFormatter.resw
@@ -156,4 +156,7 @@
   <data name="SearchKeywords" xml:space="preserve">
     <value />
   </data>
+  <data name="SortProperties" xml:space="preserve">
+    <value>Sort JSON properties alphabetically</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolViewModel.cs
@@ -118,8 +118,8 @@ namespace DevToys.ViewModels.Tools.JwtDecoderEncoder
             {
                 var handler = new JwtSecurityTokenHandler();
                 JwtSecurityToken jwtSecurityToken = handler.ReadJwtToken(input);
-                header = JsonHelper.Format(jwtSecurityToken.Header.SerializeToJson(), Indentation.TwoSpaces);
-                payload = JsonHelper.Format(jwtSecurityToken.Payload.SerializeToJson(), Indentation.TwoSpaces);
+                header = JsonHelper.Format(jwtSecurityToken.Header.SerializeToJson(), Indentation.TwoSpaces, sortProperties: false);
+                payload = JsonHelper.Format(jwtSecurityToken.Payload.SerializeToJson(), Indentation.TwoSpaces, sortProperties: false);
             }
             catch (Exception ex)
             {

--- a/src/dev/impl/DevToys/ViewModels/Tools/Formatters/JsonFormatter/JsonFormatterToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Formatters/JsonFormatter/JsonFormatterToolViewModel.cs
@@ -30,6 +30,15 @@ namespace DevToys.ViewModels.Tools.JsonFormatter
                 isRoaming: true,
                 defaultValue: Models.Indentation.TwoSpaces);
 
+        /// <summary>
+        /// Whether properties within the JSON should be sorted alphabetically or not.
+        /// </summary>
+        private static readonly SettingDefinition<bool> SortProperties
+            = new(
+                name: $"{nameof(JsonFormatterToolViewModel)}.{nameof(SortProperties)}",
+                isRoaming: true,
+                defaultValue: false);
+
         private readonly IMarketingService _marketingService;
         private readonly Queue<string> _formattingQueue = new();
 
@@ -73,6 +82,24 @@ namespace DevToys.ViewModels.Tools.JsonFormatter
             Models.IndentationDisplayPair.OneTab,
             Models.IndentationDisplayPair.Minified,
         };
+
+
+        /// <summary>
+        /// Gets or sets the whether properties within the JSON should be sorted alphabetically or not.
+        /// </summary>
+        internal bool IsSortProperties
+        {
+            get => SettingsProvider.GetSetting(SortProperties);
+            set
+            {
+                if (IsSortProperties != value)
+                {
+                    SettingsProvider.SetSetting(SortProperties, value);
+                    OnPropertyChanged();
+                    QueueFormatting();
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets the input text.
@@ -121,7 +148,7 @@ namespace DevToys.ViewModels.Tools.JsonFormatter
 
             while (_formattingQueue.TryDequeue(out string? text))
             {
-                string? result = JsonHelper.Format(text, IndentationMode.Value);
+                string? result = JsonHelper.Format(text, IndentationMode.Value, IsSortProperties);
                 if (result != null)
                 {
                     ThreadHelper.RunOnUIThreadAsync(ThreadPriority.Low, () =>

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/Base64TextEncoderDecoder/Base64EncoderDecoderToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/Base64TextEncoderDecoder/Base64EncoderDecoderToolPage.xaml
@@ -38,7 +38,6 @@
         <StackPanel Spacing="4" Grid.Row="0" >
             <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
             <controls:ExpandableSettingControl
-                Grid.Row="1"
                 Title="{x:Bind ViewModel.Strings.ConversionTitle}"
                 Description="{x:Bind ViewModel.Strings.ConversionDescription}">
                 <controls:ExpandableSettingControl.Icon>
@@ -51,7 +50,6 @@
             </controls:ExpandableSettingControl>
             <controls:ExpandableSettingControl
                 x:Name="EncodingSetting"
-                Grid.Row="2"
                 Title="{x:Bind ViewModel.Strings.EncodingTitle}"
                 Description="{x:Bind ViewModel.Strings.EncodingDescription}">
                 <controls:ExpandableSettingControl.Icon>

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/JsonFormatter/JsonFormatterToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/JsonFormatter/JsonFormatterToolPage.xaml
@@ -64,6 +64,15 @@
                     SelectedValue="{x:Bind ViewModel.IndentationMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                 </ComboBox>
             </controls:ExpandableSettingControl>
+            <controls:ExpandableSettingControl
+                Title="{x:Bind ViewModel.Strings.SortProperties}">
+                <controls:ExpandableSettingControl.Icon>
+                    <FontIcon Glyph="&#xF802;" />
+                </controls:ExpandableSettingControl.Icon>
+                <ToggleSwitch 
+                    Style="{StaticResource RightAlignedToggleSwitchStyle}"
+                    IsOn="{x:Bind ViewModel.IsSortProperties, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </controls:ExpandableSettingControl>
         </StackPanel>
 
         <Grid Grid.Row="1">

--- a/src/tests/DevToys.Tests/Helpers/JsonHelperTests.cs
+++ b/src/tests/DevToys.Tests/Helpers/JsonHelperTests.cs
@@ -29,7 +29,7 @@ namespace DevToys.Tests.Helpers
         [DataRow("   { \"foo\": 123 }  ", "{\r\n  \"foo\": 123\r\n}")]
         public void FormatTwoSpaces(string input, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.TwoSpaces));
+            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.TwoSpaces, sortProperties: false));
         }
 
         [DataTestMethod]
@@ -40,7 +40,7 @@ namespace DevToys.Tests.Helpers
         [DataRow("   { \"foo\": 123 }  ", "{\r\n    \"foo\": 123\r\n}")]
         public void FormatFourSpaces(string input, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.FourSpaces));
+            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.FourSpaces, sortProperties: false));
         }
 
         [DataTestMethod]
@@ -51,7 +51,7 @@ namespace DevToys.Tests.Helpers
         [DataRow("   { \"foo\": 123 }  ", "{\r\n\t\"foo\": 123\r\n}")]
         public void FormatOneTab(string input, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.OneTab));
+            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.OneTab, sortProperties: false));
         }
 
         [DataTestMethod]
@@ -62,14 +62,21 @@ namespace DevToys.Tests.Helpers
         [DataRow("   { \"foo\": 123 }  ", "{\"foo\":123}")]
         public void FormatMinified(string input, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.Minified));
+            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.Minified, sortProperties: false));
         }
 
         [DataTestMethod]
         [DataRow("{ \"Date\": \"2012-04-21T18:25:43-05:00\" }", "{\"Date\":\"2012-04-21T18:25:43-05:00\"}")]
         public void FormatDoesNotAlterateDateTimes(string input, string expectedResult)
         {
-            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.Minified));
+            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.Minified, sortProperties: false));
+        }
+
+        [DataTestMethod]
+        [DataRow("{\"Email\":\"john@mail.com\",\"Website\":\"http://samplewebsite.com\",\"Name\":\"John Smith\",\"Phone\":\"(50)345872\"}", "{\"Email\":\"john@mail.com\",\"Name\":\"John Smith\",\"Phone\":\"(50)345872\",\"Website\":\"http://samplewebsite.com\"}")]
+        public void FormatSortPropertiesAlphabetically(string input, string expectedResult)
+        {
+            Assert.AreEqual(expectedResult, JsonHelper.Format(input, Indentation.Minified, sortProperties: true));
         }
 
         [DataTestMethod]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

In #569, a MacOS customer was asking for a way to compare 2 JSON.
This is halfway possible in the Windows DevToys app by combining JSON Formatter and Text Diff tool. One missing piece to make it fully working is sorting the JSON properties.

## What is the new behavior?

Added a new option to sort JSON content.

## Other information

![image](https://user-images.githubusercontent.com/3747805/178118689-062ef09f-de40-49d2-985d-e7c2fb8432e1.png)

## Quality check

Before creating this PR, have you:

- [ ] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [X] Checked all unit tests pass
