### PR TITLE
Added an option to clear text editor when pasting from the clipboard.

### DIFF
--- a/src/dev/impl/DevToys/Core/Settings/PredefinedSettings.cs
+++ b/src/dev/impl/DevToys/Core/Settings/PredefinedSettings.cs
@@ -122,5 +122,14 @@ namespace DevToys.Core.Settings
                 name: nameof(TextEditorRenderWhitespace),
                 isRoaming: true,
                 defaultValue: false);
+
+        /// <summary>
+        /// Whether when using the Paste command, the text in the editor should be replaced or appended.
+        /// </summary>
+        public static readonly SettingDefinition<bool> TextEditorPasteClearsText
+            = new(
+                name: nameof(TextEditorPasteClearsText),
+                isRoaming: true,
+                defaultValue: false);
     }
 }

--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -2332,6 +2332,16 @@ namespace DevToys
         /// Gets the resource HelpTranslating.
         /// </summary>
         public string HelpTranslating => _resources.GetString("HelpTranslating");
+
+        /// <summary>
+        /// Gets the resource PasteClearsText.
+        /// </summary>
+        public string PasteClearsText => _resources.GetString("PasteClearsText");
+
+        /// <summary>
+        /// Gets the resource PasteClearsTextDescription.
+        /// </summary>
+        public string PasteClearsTextDescription => _resources.GetString("PasteClearsTextDescription");
     }
 
     public class SqlFormatterStrings : ObservableObject

--- a/src/dev/impl/DevToys/Strings/en-US/Settings.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/Settings.resw
@@ -234,4 +234,10 @@
   <data name="HelpTranslating" xml:space="preserve">
     <value>Help us translating DevToys!</value>
   </data>
+  <data name="PasteClearsText" xml:space="preserve">
+    <value>Replace text when pasting</value>
+  </data>
+  <data name="PasteClearsTextDescription" xml:space="preserve">
+    <value>When clicking the Paste button, clear the text before pasting instead of appending to the existing text editor content.</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml
+++ b/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml
@@ -134,7 +134,7 @@
                 SelectionChanged="TextBox_SelectionChanged"
                 CopyingToClipboard="TextBox_CopyingToClipboard"
                 CuttingToClipboard="TextBox_CuttingToClipboard"
-                AutomationProperties.LabeledBy="{Binding ElementName=HeaderTextBlock}" Loading="TextBox_Loading" />
+                AutomationProperties.LabeledBy="{Binding ElementName=HeaderTextBlock}"/>
             <RichEditBox
                 x:Name="RichEditBox"
                 x:Load="{x:Bind IsRichTextEdit}"

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/Base64ImageEncoderDecoder/MockSettingsProvider.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/Base64ImageEncoderDecoder/MockSettingsProvider.cs
@@ -16,6 +16,12 @@ namespace DevToys.ViewModels.Tools.Base64ImageEncoderDecoder
         public MockSettingsProvider(ISettingsProvider realSettingsProvider)
         {
             _realSettingsProvider = realSettingsProvider;
+            _realSettingsProvider.SettingChanged += realSettingsProvider_SettingChanged;
+        }
+
+        private void realSettingsProvider_SettingChanged(object sender, SettingChangedEventArgs e)
+        {
+            SettingChanged?.Invoke(this, e);
         }
 
         public T GetSetting<T>(SettingDefinition<T> settingDefinition)

--- a/src/dev/impl/DevToys/ViewModels/Tools/Settings/SettingsToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Settings/SettingsToolViewModel.cs
@@ -92,6 +92,12 @@ namespace DevToys.ViewModels.Settings
             set => _settingsProvider.SetSetting(PredefinedSettings.TextEditorRenderWhitespace, value);
         }
 
+        internal bool TextEditorPasteClearsText
+        {
+            get => _settingsProvider.GetSetting(PredefinedSettings.TextEditorPasteClearsText);
+            set => _settingsProvider.SetSetting(PredefinedSettings.TextEditorPasteClearsText, value);
+        }
+
         /// <summary>
         /// Gets the version of the application.
         /// </summary>

--- a/src/dev/impl/DevToys/Views/Tools/Converters/JsonYaml/JsonYamlToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Converters/JsonYaml/JsonYamlToolPage.xaml
@@ -96,7 +96,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.Input}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 CodeLanguage="{x:Bind ViewModel.InputValueLanguage, Mode=OneWay}"/>
 
@@ -139,7 +138,6 @@
                 Grid.RowSpan="3"
                 IsReadOnly="True"
                 Header="{x:Bind ViewModel.Strings.Output}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.OutputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 CodeLanguage="{x:Bind ViewModel.OutputValueLanguage, Mode=OneWay}"/>
         </Grid>

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/JsonFormatter/JsonFormatterToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/JsonFormatter/JsonFormatterToolPage.xaml
@@ -84,7 +84,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.Input}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 CodeLanguage="json"/>
 
@@ -126,7 +125,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.Output}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
                 CodeLanguage="json"
                 IsReadOnly="True"/>

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/SqlFormatter/SqlFormatterToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/SqlFormatter/SqlFormatterToolPage.xaml
@@ -98,7 +98,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.Input}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 CodeLanguage="sql"/>
 
@@ -140,7 +139,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.Output}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
                 CodeLanguage="sql"
                 IsReadOnly="True"/>

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/XmlFormatter/XmlFormatterToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/XmlFormatter/XmlFormatterToolPage.xaml
@@ -96,7 +96,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.Input}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 CodeLanguage="xml"/>
 
@@ -138,7 +137,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.Output}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
                 CodeLanguage="xml"
                 IsReadOnly="True"/>

--- a/src/dev/impl/DevToys/Views/Tools/Generators/GuidGenerator/GuidGeneratorToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Generators/GuidGenerator/GuidGeneratorToolPage.xaml
@@ -112,7 +112,6 @@
             AcceptsReturn="True"
             IsReadOnly="True"
             CanClearWhenReadOnly="True"
-            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.Output, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Generators/HashGenerator/HashGeneratorToolPage.xaml
@@ -71,25 +71,21 @@
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.MD5}"
             IsReadOnly="True"
-            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.MD5, Mode=OneWay}"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.SHA1}"
             IsReadOnly="True"
-            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.SHA1, Mode=OneWay}"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.SHA256}"
             IsReadOnly="True"
-            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.SHA256, Mode=OneWay}"/>
 
         <controls:CustomTextBox
             Header="{x:Bind ViewModel.Strings.SHA512}"
             IsReadOnly="True"
-            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.SHA512, Mode=OneWay}"/>
     </StackPanel>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Settings/SettingsToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Settings/SettingsToolPage.xaml
@@ -126,6 +126,14 @@
             </controls:ExpandableSettingControl.Icon>
             <ToggleSwitch Style="{StaticResource RightAlignedToggleSwitchStyle}" IsOn="{x:Bind ViewModel.TextEditorRenderWhitespace, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
         </controls:ExpandableSettingControl>
+        <controls:ExpandableSettingControl
+            Title="{x:Bind ViewModel.Strings.PasteClearsText}"
+            Description="{x:Bind ViewModel.Strings.PasteClearsTextDescription}">
+            <controls:ExpandableSettingControl.Icon>
+                <FontIcon Glyph="&#xF2D5;" />
+            </controls:ExpandableSettingControl.Icon>
+            <ToggleSwitch Style="{StaticResource RightAlignedToggleSwitchStyle}" IsOn="{x:Bind ViewModel.TextEditorPasteClearsText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+        </controls:ExpandableSettingControl>
 
         <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.About}" />
 

--- a/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/MarkdownPreview/MarkdownPreviewToolPage.xaml
@@ -91,7 +91,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.Input}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 CodeLanguage="markdown"/>
 

--- a/src/dev/impl/DevToys/Views/Tools/Text/RegEx/RegExToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/RegEx/RegExToolPage.xaml
@@ -101,7 +101,6 @@
         <controls:CustomTextBox
             Grid.Row="1"
             Header="{x:Bind ViewModel.Strings.RegularExpression}"
-            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.RegularExpression, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
         <controls:CustomTextBox
@@ -111,7 +110,6 @@
             AcceptsReturn="True"
             IsRichTextEdit="True"
             MinHeight="150"
-            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             Text="{x:Bind ViewModel.Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml
@@ -70,7 +70,6 @@
                 Grid.Column="0"
                 MinHeight="200"
                 Header="{x:Bind ViewModel.Strings.LeftText}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.OldText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
             <toolkit:GridSplitter
@@ -92,7 +91,6 @@
                 Grid.Column="2"
                 MinHeight="200"
                 Header="{x:Bind ViewModel.Strings.RightText}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.NewText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
         </Grid>
 
@@ -114,7 +112,6 @@
             MinHeight="200"
             Grid.Row="3"
             Header="{x:Bind ViewModel.Strings.Difference}"
-            SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
             IsReadOnly="True"
             IsDiffViewMode="True"
             InlineDiffViewMode="{x:Bind ViewModel.InlineMode, Mode=OneWay}"

--- a/src/dev/impl/DevToys/Views/Tools/Text/XmlValidator/XmlValidatorToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/XmlValidator/XmlValidatorToolPage.xaml
@@ -69,7 +69,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.XsdScheme}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.XsdSchema, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 CodeLanguage="xml"/>
 
@@ -111,7 +110,6 @@
                 Grid.Row="0"
                 Grid.RowSpan="3"
                 Header="{x:Bind ViewModel.Strings.XmlData}"
-                SettingsProvider="{x:Bind ViewModel.SettingsProvider}"
                 Text="{x:Bind ViewModel.XmlData, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 CodeLanguage="xml"/>
         </Grid>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [X] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #562

## What is the new behavior?

- Added a new option in the Settings allowing the user to clear the text box when pasting from the clipboard, so it replaces the content of the text box by the one from the clipboard.
- Fixed a bug where Base64 Image Encoder / Decoder doesn't update accordingly to the user settings changes.
- Applied the font settings in every text editor.

## Other information

![image](https://user-images.githubusercontent.com/3747805/178121417-c85ea8ef-7995-4d79-b780-213f54e494e6.png)

## Quality check

Before creating this PR, have you:

- [ ] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Verified that the change work in Release build configuration
- [ ] Checked all unit tests pass
