### PR TITLE
Leverage favorites for recommended tool providers

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/MainPageViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/MainPageViewModel.cs
@@ -666,8 +666,9 @@ namespace DevToys.ViewModels
 
             using (await _sempahore.WaitAsync(CancellationToken.None).ConfigureAwait(false))
             {
-                if (newRecommendedTools.Length == 1
-                    && IsToolDisplayedInMenu(ToolsMenuItems.OfType<ToolProviderViewItem>(), newRecommendedTools[0]))
+                ToolProviderViewItem? toolProvider = GetRecommendedToolProvider(newRecommendedTools);
+                if (toolProvider != null
+                    && IsToolDisplayedInMenu(ToolsMenuItems.OfType<ToolProviderViewItem>(), toolProvider))
                 {
                     // One unique tool is recommended.
                     // The recommended tool is displayed in the top menu.
@@ -679,11 +680,26 @@ namespace DevToys.ViewModels
                         {
                             if (!IsInCompactOverlayMode && _allowSelectAutomaticallyRecommendedTool)
                             {
-                                SetSelectedMenuItem(newRecommendedTools[0], _clipboardContent);
+                                SetSelectedMenuItem(toolProvider, _clipboardContent);
                             }
                         });
                 }
             }
+        }
+
+        private ToolProviderViewItem? GetRecommendedToolProvider(ToolProviderViewItem[] items)
+        {
+            ToolProviderViewItem favoriteItem = items.FirstOrDefault(i => i.IsFavorite);
+            if (favoriteItem != null)
+            {
+                return favoriteItem;
+            }
+            else if (items.Length == 1)
+            {
+                return items[0];
+            }
+
+            return null;
         }
 
         private bool IsToolDisplayedInMenu(IEnumerable<ToolProviderViewItem> tools, ToolProviderViewItem ToolProviderViewItem)


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [✓] Feature


## What is the current behavior?

Like discussed in [Issue 600](https://github.com/veler/DevToys/issues/600)
Even if there's multiple recommended ToolProviders, the tool selection is triggered if there's one in the favorites.

Issue Number: **600**

## Quality check

Before creating this PR, have you:

- [✓] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [✓] Verified that the change work in Release build configuration
- [✓] Checked all unit tests pass
