### PR TITLE
Fix JsonHelper.Format failing when deserializing top-level array objects

### DIFF
--- a/src/dev/impl/DevToys/Helpers/JsonYaml/JsonHelper.cs
+++ b/src/dev/impl/DevToys/Helpers/JsonYaml/JsonHelper.cs
@@ -69,18 +69,25 @@ namespace DevToys.Helpers.JsonYaml
                     LineInfoHandling = LineInfoHandling.Load
                 };
 
-                JObject jObject;
+                JToken jToken;
                 using (var jsonReader = new JsonTextReader(new StringReader(input)))
                 {
                     jsonReader.DateParseHandling = DateParseHandling.None;
                     jsonReader.DateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
 
-                    jObject = JObject.Load(jsonReader, jsonLoadSettings);
+                    jToken = JToken.Load(jsonReader, jsonLoadSettings);
                 }
 
                 if (sortProperties)
                 {
-                    SortJsonPropertiesAlphabetically(jObject);
+                    if (jToken is JObject obj)
+                    {
+                        SortJsonPropertiesAlphabetically(obj);
+                    }
+                    else if (jToken is JArray array)
+                    {
+                        SortJsonPropertiesAlphabetically(array);
+                    }
                 }
 
                 var stringBuilder = new StringBuilder();
@@ -114,7 +121,7 @@ namespace DevToys.Helpers.JsonYaml
                     jsonTextWriter.DateFormatHandling = DateFormatHandling.IsoDateFormat;
                     jsonTextWriter.DateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
 
-                    jObject.WriteTo(jsonTextWriter);
+                    jToken.WriteTo(jsonTextWriter);
                 }
 
                 return stringBuilder.ToString();
@@ -215,13 +222,22 @@ namespace DevToys.Helpers.JsonYaml
                 }
                 else if (property.Value is JArray array)
                 {
-                    foreach (JToken? arrayItem in array)
-                    {
-                        if (arrayItem is JObject arrayObj)
-                        {
-                            SortJsonPropertiesAlphabetically(arrayObj);
-                        }
-                    }
+                    SortJsonPropertiesAlphabetically(array);
+                }
+            }
+        }
+
+        private static void SortJsonPropertiesAlphabetically(JArray jArray)
+        {
+            foreach (JToken? arrayItem in jArray)
+            {
+                if (arrayItem is JObject arrayObj)
+                {
+                    SortJsonPropertiesAlphabetically(arrayObj);
+                }
+                else if (arrayItem is JArray array)
+                {
+                    SortJsonPropertiesAlphabetically(array);
                 }
             }
         }

--- a/src/tests/DevToys.Tests/Helpers/JsonHelperTests.cs
+++ b/src/tests/DevToys.Tests/Helpers/JsonHelperTests.cs
@@ -14,6 +14,7 @@ namespace DevToys.Tests.Helpers
         [DataRow("", false)]
         [DataRow(" ", false)]
         [DataRow("   {  }  ", true)]
+        [DataRow("   [  ]  ", true)]
         [DataRow("   { \"foo\": 123 }  ", true)]
         [DataRow("   bar { \"foo\": 123 }  ", false)]
         public void IsValid(string input, bool expectedResult)
@@ -26,6 +27,7 @@ namespace DevToys.Tests.Helpers
         [DataRow("", "")]
         [DataRow(" ", "")]
         [DataRow("   {  }  ", "{}")]
+        [DataRow("   [  ]  ", "[]")]
         [DataRow("   { \"foo\": 123 }  ", "{\r\n  \"foo\": 123\r\n}")]
         public void FormatTwoSpaces(string input, string expectedResult)
         {
@@ -37,6 +39,7 @@ namespace DevToys.Tests.Helpers
         [DataRow("", "")]
         [DataRow(" ", "")]
         [DataRow("   {  }  ", "{}")]
+        [DataRow("   [  ]  ", "[]")]
         [DataRow("   { \"foo\": 123 }  ", "{\r\n    \"foo\": 123\r\n}")]
         public void FormatFourSpaces(string input, string expectedResult)
         {
@@ -48,6 +51,7 @@ namespace DevToys.Tests.Helpers
         [DataRow("", "")]
         [DataRow(" ", "")]
         [DataRow("   {  }  ", "{}")]
+        [DataRow("   [  ]  ", "[]")]
         [DataRow("   { \"foo\": 123 }  ", "{\r\n\t\"foo\": 123\r\n}")]
         public void FormatOneTab(string input, string expectedResult)
         {
@@ -59,6 +63,7 @@ namespace DevToys.Tests.Helpers
         [DataRow("", "")]
         [DataRow(" ", "")]
         [DataRow("   {  }  ", "{}")]
+        [DataRow("   [  ]  ", "[]")]
         [DataRow("   { \"foo\": 123 }  ", "{\"foo\":123}")]
         public void FormatMinified(string input, string expectedResult)
         {


### PR DESCRIPTION
Adds appropriate test cases to JsonHelperTests

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Current behavior will deserialize the Input field of the JsonFormatter as a JObject, which will work as expected for top-level values and object definitions. But when the top-level object is an array, it cannot be serialized to this type, and instead writes the exception body to the Output.

Issue Number: #620

## What is the new behavior?

The new behavior deserializes the Input text as a JToken, which is able to represent both JObject and JArray types. To handle sorting properties recursively, I created an overload of JsonFormatter.SortJsonPropertiesAlphabetically for JArray objects. Both methods were modified to recursively call eachother based on the property's JToken type.

## Other information

![image](https://user-images.githubusercontent.com/111713433/185838859-ff7b9d02-9e1a-4e2a-8b54-c5612ca718c9.png)

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass
