### PR TITLE
Fix Base64 encoder crashing with different themes

### DIFF
--- a/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
+++ b/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
@@ -366,9 +366,12 @@ namespace DevToys.UI.Controls
             }
             else
             {
-                ITextRange range = richEditBox.TextDocument.GetRange(0, Text.Length);
-                range.CharacterFormat.BackgroundColor = Colors.Transparent;
-                range.CharacterFormat.ForegroundColor = ActualTheme == ElementTheme.Dark ? Colors.White : Colors.Black;
+                if (!IsReadOnly)
+                {
+                    ITextRange range = richEditBox.TextDocument.GetRange(0, Text.Length);
+                    range.CharacterFormat.BackgroundColor = Colors.Transparent;
+                    range.CharacterFormat.ForegroundColor = ActualTheme == ElementTheme.Dark ? Colors.White : Colors.Black;
+                }
             }
 
             richEditBox.TextDocument.ApplyDisplayUpdates();

--- a/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
+++ b/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs
@@ -319,7 +319,7 @@ namespace DevToys.UI.Controls
         {
             _highlightedSpans = spans ?? Array.Empty<HighlightSpan>();
 
-            if (!IsRichTextEdit)
+            if (!IsRichTextEdit || IsReadOnly)
             {
                 return;
             }
@@ -366,12 +366,9 @@ namespace DevToys.UI.Controls
             }
             else
             {
-                if (!IsReadOnly)
-                {
-                    ITextRange range = richEditBox.TextDocument.GetRange(0, Text.Length);
-                    range.CharacterFormat.BackgroundColor = Colors.Transparent;
-                    range.CharacterFormat.ForegroundColor = ActualTheme == ElementTheme.Dark ? Colors.White : Colors.Black;
-                }
+                ITextRange range = richEditBox.TextDocument.GetRange(0, Text.Length);
+                range.CharacterFormat.BackgroundColor = Colors.Transparent;
+                range.CharacterFormat.ForegroundColor = ActualTheme == ElementTheme.Dark ? Colors.White : Colors.Black;
             }
 
             richEditBox.TextDocument.ApplyDisplayUpdates();

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/Base64TextEncoderDecoder/Base64EncoderDecoderToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/Base64TextEncoderDecoder/Base64EncoderDecoderToolPage.xaml
@@ -77,7 +77,6 @@
             MinHeight="150"
             IsReadOnly="True"
             AcceptsReturn="True"
-            IsRichTextEdit="True"
             Header="{x:Bind ViewModel.Strings.OutputTitle}"
             Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"/>
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Opening the Base64 Encoder/Decoder tool using a theme that does not match the current "Default App Mode" in Windows will cause the application to crash.

Issue Number: #675

## What is the new behavior?

The Base64 Encoder/Decoder tool should now open properly with both theme settings.

## Other information

The apparent cause for this problem is that having a CustomTextBox's `IsReadOnly` and `IsRichTextEdit` properties both set to `true` at the same time will cause issues when the [`SetHighlights()`](https://github.com/veler/DevToys/blob/5a8c0a5634b20d10781307f15b07df3313580099/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs#L318) method is called, as it will always try to set a BackgroundColor and ForegroundColor, causing an exception with the message `Access is denied. (Exception from HRESULT: 0x80070005)` to be thrown.

I believe this only causes a crash when the theme is the opposite of the current system's because that apparently makes the `ActualThemeChanged` event to fire every time a [CustomTextBox.xaml.cs](https://github.com/veler/DevToys/blob/5a8c0a5634b20d10781307f15b07df3313580099/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs) is displayed, and the `OnActualThemeChanged()` method calls [`SetHighlights()`](https://github.com/veler/DevToys/blob/5a8c0a5634b20d10781307f15b07df3313580099/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs#L318), which will fail under the conditions described.

For the actual fix, I Simply made it so [`SetHighlights()`](https://github.com/veler/DevToys/blob/5a8c0a5634b20d10781307f15b07df3313580099/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml.cs#L318) returns early if the component is read only and also changed the output `CustomTextBox` in [`Base64EncoderDecoderToolPage.xaml`](https://github.com/veler/DevToys/blob/main/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/Base64TextEncoderDecoder/Base64EncoderDecoderToolPage.xaml) so that it does not have `IsRichTextEdit` set to `true`, since in other tool pages that seems to be the case as well.

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass
