### PR TITLE
Allowing Vertical Stretch of JWT Header and Payload sections

### DIFF
--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
@@ -40,7 +40,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto" MinHeight="100"/>
-            <RowDefinition Height="Auto" MinHeight="300"/>
+            <RowDefinition Height="*" MinHeight="300"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <StackPanel

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolPage.xaml
@@ -24,7 +24,7 @@
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
         <StackPanel Spacing="0" Grid.Row="0" Margin="0,0,0,-8" >

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtEncoderControl.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtEncoderControl.xaml
@@ -41,7 +41,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto" MinHeight="5"/>
             <RowDefinition Height="Auto" MinHeight="100"/>
-            <RowDefinition Height="Auto" MinHeight="250"/>
+            <RowDefinition Height="*" MinHeight="250"/>
             <RowDefinition Height="Auto" MinHeight="250"/>
         </Grid.RowDefinitions>
         <StackPanel


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

JWT Encoder/Decoder uses only a fixed amount of vertical space for Payload. With short tokens this just leaves empty visual space at the bottom but for tokens with many claims it requires scrolling no matter what size the window is.

Issue Number: N/A

## What is the new behavior?

- Encoder and Decoder Page expands vertically to fill available window space
- Header and Payload sections expand vertically to fill the available page space
- Minimum vertical sizes are unchanged so still enable scrolling on short window heights

## Other information

Behavior Before:
![VerticalStretchBefore](https://user-images.githubusercontent.com/7328030/224589333-b6d0cdfd-956a-4d7f-9814-30e8612360ee.png)

Behavior After:
![VerticalStretchAfter](https://user-images.githubusercontent.com/7328030/224589334-e118966b-c57a-447e-8905-ea4281f8858a.png)

## Quality check

Before creating this PR, have you:

- [ x ] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ x ] Verified that the change work in Release build configuration
- [ x ] Checked all unit tests pass
