### PR TITLE
Fixing bug in sql formatter where values provided after reserved 'VALUES' keyword were not being indented properly

### DIFF
--- a/src/dev/impl/DevToys/Helpers/SqlFormatter/Core/Formatter.cs
+++ b/src/dev/impl/DevToys/Helpers/SqlFormatter/Core/Formatter.cs
@@ -224,7 +224,8 @@ namespace DevToys.Helpers.SqlFormatter.Core
             {
                 Token? behindToken = TokenLookBehind();
 
-                if (behindToken is not { Type: TokenType.OpenParen or TokenType.LineComment or TokenType.Operator })
+                if (behindToken is not { Type: TokenType.OpenParen or TokenType.LineComment or TokenType.Operator }
+                    && !behindToken?.IsValues(querySpan.Slice(behindToken!.Value)) == true)
                 {
                     _queryBuilder.TrimSpaceEnd();
                 }

--- a/src/dev/impl/DevToys/Helpers/SqlFormatter/Core/TokenHelper.cs
+++ b/src/dev/impl/DevToys/Helpers/SqlFormatter/Core/TokenHelper.cs
@@ -42,6 +42,11 @@ namespace DevToys.Helpers.SqlFormatter.Core
             return IsToken(token.Type, TokenType.CloseParen, tokenValueSpan, "END".AsSpan());
         }
 
+        internal static bool IsValues(this Token token, ReadOnlySpan<char> tokenValueSpan)
+        {
+            return IsToken(token.Type, TokenType.ReservedTopLevel, tokenValueSpan, "VALUES".AsSpan());
+        }
+
         private static bool IsToken(TokenType type, TokenType otherType,
             ReadOnlySpan<char> tokenValueSpan, ReadOnlySpan<char> otherSpan)
         {

--- a/src/tests/DevToys.Tests/Providers/Tools/SqlFormatterTests.cs
+++ b/src/tests/DevToys.Tests/Providers/Tools/SqlFormatterTests.cs
@@ -1045,6 +1045,22 @@ SELECT
 FROM
   tbl2;";
             AssertFormat(formatter, input, expectedResult);
+
+            // correctly formats hardcoded values in from statement
+            input =
+@"SELECT Id FROM (values(1),(2),(3), (4)) as  b  (id)";
+            expectedResult =
+@"SELECT
+  Id
+FROM
+  (
+    values
+      (1),
+      (2),
+      (3),
+      (4)
+  ) as b (id)";
+            AssertFormat(formatter, input, expectedResult);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #773

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The reserved keyword of "VALUES" will also be considered when omitting trimming of the end of new line spacing while formatting SQL.  The current implementation includes `LineComment`, `Operator`, and `OpenParen`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

![image](https://user-images.githubusercontent.com/74258557/229782984-baf89d49-0f11-46da-9d2f-c61886367a0f.png)


## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)