### PR TITLE
Adding url encoding wrapper function to handle xaml textbox conversio…

### DIFF
--- a/src/dev/impl/DevToys/DevToys.csproj
+++ b/src/dev/impl/DevToys/DevToys.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Helpers\NumberBaseHelper.cs" />
     <Compile Include="Helpers\StringManipulationHelper.cs" />
     <Compile Include="Helpers\TimestampToolHelper.cs" />
+    <Compile Include="Helpers\UrlHelper.cs" />
     <Compile Include="Helpers\XmlHelper.cs" />
     <Compile Include="Helpers\SqlFormatter\Core\Formatter.cs" />
     <Compile Include="Helpers\SqlFormatter\Core\Indentation.cs" />

--- a/src/dev/impl/DevToys/Helpers/UrlHelper.cs
+++ b/src/dev/impl/DevToys/Helpers/UrlHelper.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace DevToys.Helpers
+{
+    internal static class UrlHelper
+    {
+        /// <summary>
+        /// Url encodes a string.
+        /// This is a wrapper function for the built in System.Uri api to accommodate this issue:
+        /// https://github.com/microsoft/microsoft-ui-xaml/issues/1826
+        /// </summary>
+        /// <param name="data">Input to url encode</param>
+        /// <returns>Url encoded result</returns>
+        internal static string UrlEncode(string data)
+        {
+            string newLineAdjusted = data.Replace("\r\n", "\n").Replace("\r", "\n");
+            string encoded = Uri.EscapeDataString(newLineAdjusted);
+
+            return encoded;
+        }
+    }
+}

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/UrlEncoderDecoder/UrlEncoderDecoderToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/UrlEncoderDecoder/UrlEncoderDecoderToolViewModel.cs
@@ -9,6 +9,7 @@ using DevToys.Api.Core.Settings;
 using DevToys.Api.Tools;
 using DevToys.Core;
 using DevToys.Core.Threading;
+using DevToys.Helpers;
 using DevToys.Shared.Core.Threading;
 using DevToys.Views.Tools.UrlEncoderDecoder;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
@@ -151,7 +152,7 @@ namespace DevToys.ViewModels.Tools.UrlEncoderDecoder
             string? encoded;
             try
             {
-                encoded = Uri.EscapeDataString(data);
+                encoded = UrlHelper.UrlEncode(data!);
             }
             catch (Exception ex)
             {

--- a/src/tests/DevToys.Tests/DevToys.Tests.csproj
+++ b/src/tests/DevToys.Tests/DevToys.Tests.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="Helpers\JwtHelperTests.cs" />
     <Compile Include="Helpers\Base64HelperTests.cs" />
+    <Compile Include="Helpers\UrlHelperTests.cs" />
     <Compile Include="Helpers\XmlHelperTests.cs" />
     <Compile Include="Providers\Tools\BaseNumberFormatterTests.cs" />
     <Compile Include="Core\Threading\AsyncLazyTests.cs" />

--- a/src/tests/DevToys.Tests/Helpers/UrlHelperTests.cs
+++ b/src/tests/DevToys.Tests/Helpers/UrlHelperTests.cs
@@ -1,0 +1,18 @@
+﻿using DevToys.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DevToys.Tests.Helpers
+{
+    [TestClass]
+    public class UrlHelperTests
+    {
+        [DataTestMethod]
+        [DataRow("123\r456", "123%0A456")]
+        [DataRow("test\r", "test%0A")]
+        [DataRow("hello\r\nworld", "hello%0Aworld")]
+        public void EncodeNewLines(string input, string expectedResult)
+        {
+            Assert.AreEqual(expectedResult, UrlHelper.UrlEncode(input));
+        }
+    }
+}


### PR DESCRIPTION
…n of new line to only carriage return

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #758 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Due to https://github.com/microsoft/microsoft-ui-xaml/issues/1826, it seems that the xaml textbox is converting a new line to a single carriage return.  This resulted in the url encoding not properly handling the user input.  This change will support if the decision is made to convert to carriage return + line feed or just line feeds.


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
![screenshot](https://user-images.githubusercontent.com/74258557/230197151-ca0de2b4-9504-481d-8808-8dabb33b7722.gif)



## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)