### PR TITLE
Clear Payload when empty JWT provided

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControlViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControlViewModel.cs
@@ -38,6 +38,8 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
         {
             if (string.IsNullOrWhiteSpace(Token))
             {
+                ClearPayload();
+
                 return;
             }
 
@@ -111,9 +113,14 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
             ThreadHelper.RunOnUIThreadAsync(ThreadPriority.Low, () =>
             {
                 Header = string.Empty;
-                Payload = string.Empty;
+                ClearPayload();
                 DisplayValidationInfoBar();
             }).ForgetSafely();
+        }
+
+        private void ClearPayload()
+        {
+            Payload = string.Empty;
         }
     }
 }


### PR DESCRIPTION
**In JWT Encoder / Decoder, Clear Payload when empty JWT provided.**

## Pull request type

- [X] Bugfix

## What is the current behavior?

**Until now, when the JWT was cleared, the payload was kept**

#777 

## What is the new behavior?

Now, when an empty JWT is in the editor, because it's cleared, the payload is also cleared