### PR TITLE
Fixed sql formatting for logical operators

### DIFF
--- a/src/dev/impl/DevToys/Helpers/SqlFormatter/Core/Tokenizer.cs
+++ b/src/dev/impl/DevToys/Helpers/SqlFormatter/Core/Tokenizer.cs
@@ -53,7 +53,7 @@ namespace DevToys.Helpers.SqlFormatter.Core
             string[] specialWordChars,
             string[]? operators = null)
         {
-            var operatorsParam = new List<string> { "<>", "<=", ">=" };
+            var operatorsParam = new List<string> { "<>", "<=", ">=", "&&", "||", "!=" };
             if (operators is not null)
             {
                 operatorsParam.AddRange(operators);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #816

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
I corrected wrong formatting, similar behavior appears when selecting TSQL, Standart Sql, Postgres, N1QL

Before correction:
Input:
<pre>
<code>
SELECT
  U1.FULL_NAME || ' (' || U1.USER_NAME || ')' AS CREATED_BY,
  U2.FULL_NAME || ' (' || U2.USER_NAME || ')' AS LAST_EDITED_BY
FROM SOMETABLE
</code>
</pre>
Output:
<pre>
<code>
SELECT
  U1.FULL_NAME | | ' (' | | U1.USER_NAME | | ')' AS CREATED_BY,
  U2.FULL_NAME | | ' (' | | U2.USER_NAME | | ')' AS LAST_EDITED_BY
FROM
  SOMETABLE
</code>
</pre>

After correcting:
Input:
<pre>
<code>
SELECT
  U1.FULL_NAME || ' (' || U1.USER_NAME || ')' AS CREATED_BY,
  U2.FULL_NAME || ' (' || U2.USER_NAME || ')' AS LAST_EDITED_BY
FROM SOMETABLE
</code>
</pre>
Output:
<pre>
<code>
SELECT
  U1.FULL_NAME || ' (' || U1.USER_NAME || ')' AS CREATED_BY,
  U2.FULL_NAME || ' (' || U2.USER_NAME || ')' AS LAST_EDITED_BY
FROM
  SOMETABLE
</code>
</pre>

I tested these operators '&&', '!=' and they were also formatted incorrectly
I fixed this
Before correction:
Input:
<pre>
<code>
SELECT
  U1.FULL_NAME && ' (' && U1.USER_NAME && ')' AS CREATED_BY,
  U2.FULL_NAME && ' (' != U2.USER_NAME &&')' AS LAST_EDITED_BY
FROM SOMETABLE
</code>
</pre>
Output
<pre>
<code>
SELECT
   U1.FULL_NAME & & ' (' & & U1.USER_NAME & & ')' AS CREATED_BY,
   U2.FULL_NAME & & ' (' ! = U2.USER_NAME & & ')' AS LAST_EDITED_BY
FROM
  SOMETABLE
</code>
</pre>

After correcting:
Input:
<pre>
<code>
SELECT
  U1.FULL_NAME && ' (' && U1.USER_NAME && ')' AS CREATED_BY,
  U2.FULL_NAME && ' (' != U2.USER_NAME &&')' AS LAST_EDITED_BY
FROM SOMETABLE
</code>
</pre>
Output
<pre>
<code>
SELECT
   U1.FULL_NAME && ' (' && U1.USER_NAME && ')' AS CREATED_BY,
   U2.FULL_NAME && ' (' != U2.USER_NAME && ')' AS LAST_EDITED_BY
FROM
  SOMETABLE
</code>
</pre>


## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)