### PR TITLE
Add line sorting to string utils

### DIFF
--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -3001,6 +3001,11 @@ namespace DevToys
         public string Convert => _resources.GetString("Convert");
 
         /// <summary>
+        /// Gets the resource Sort.
+        /// </summary>
+        public string Sort => _resources.GetString("Sort");
+
+        /// <summary>
         /// Gets the resource MenuDisplayName.
         /// </summary>
         public string MenuDisplayName => _resources.GetString("MenuDisplayName");
@@ -3014,6 +3019,36 @@ namespace DevToys
         /// Gets the resource KebabCase.
         /// </summary>
         public string KebabCase => _resources.GetString("KebabCase");
+
+        /// <summary>
+        /// Gets the resource Alphabetize.
+        /// </summary>
+        public string Alphabetize => _resources.GetString("Alphabetize");
+
+        /// <summary>
+        /// Gets the resource ReverseAlphabetize.
+        /// </summary>
+        public string ReverseAlphabetize => _resources.GetString("ReverseAlphabetize");
+
+        /// <summary>
+        /// Gets the resource AlphabetizeLast.
+        /// </summary>
+        public string AlphabetizeLast => _resources.GetString("AlphabetizeLast");
+
+        /// <summary>
+        /// Gets the resource ReverseAlphabetizeLast.
+        /// </summary>
+        public string ReverseAlphabetizeLast => _resources.GetString("ReverseAlphabetizeLast");
+
+        /// <summary>
+        /// Gets the resource Reverse.
+        /// </summary>
+        public string Reverse => _resources.GetString("Reverse");
+
+        /// <summary>
+        /// Gets the resource Randomize.
+        /// </summary>
+        public string Randomize => _resources.GetString("Randomize");
 
         /// <summary>
         /// Gets the resource Line.

--- a/src/dev/impl/DevToys/Strings/en-US/StringUtilities.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/StringUtilities.resw
@@ -147,6 +147,9 @@
   <data name="Convert" xml:space="preserve">
     <value>Convert</value>
   </data>
+  <data name="Sort" xml:space="preserve">
+    <value>Sort Lines</value>
+  </data>
   <data name="MenuDisplayName" xml:space="preserve">
     <value>Inspector &amp; Case Converter</value>
   </data>
@@ -155,6 +158,24 @@
   </data>
   <data name="KebabCase" xml:space="preserve">
     <value>kebab-case</value>
+  </data>
+  <data name="Alphabetize" xml:space="preserve">
+    <value>Alphabetize</value>
+  </data>
+  <data name="ReverseAlphabetize" xml:space="preserve">
+    <value>Reverse alphabetize</value>
+  </data>
+  <data name="AlphabetizeLast" xml:space="preserve">
+    <value>Alphabetize by last word</value>
+  </data>
+  <data name="ReverseAlphabetizeLast" xml:space="preserve">
+    <value>Reverse alphabetize by last word</value>
+  </data>
+  <data name="Reverse" xml:space="preserve">
+    <value>Reverse</value>
+  </data>
+  <data name="Randomize" xml:space="preserve">
+    <value>Randomize</value>
   </data>
   <data name="Line" xml:space="preserve">
     <value>Line:</value>

--- a/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
@@ -702,13 +702,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 string? line1LastWord = line1.Split(' ', ',').LastOrDefault();
                 string? line2LastWord = line2.Split(' ', ',').LastOrDefault();
 
-                if (string.Equals(line1LastWord, line2LastWord, StringComparison.CurrentCulture))
-                {
-                    return 0;
-                }
-
-                var newList = new List<string> { line1LastWord, line2LastWord }.OrderBy(word => word).ToList();
-                return newList.IndexOf(line1LastWord) == 0 ? -1 : 1;
+                return string.Compare(line1LastWord, line2LastWord, StringComparison.CurrentCulture);
             });
             text = string.Join('\r', lines);
 
@@ -740,13 +734,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 string? line1LastWord = line1.Split(' ', ',').LastOrDefault();
                 string? line2LastWord = line2.Split(' ', ',').LastOrDefault();
 
-                if (string.Equals(line1LastWord, line2LastWord, StringComparison.CurrentCulture))
-                {
-                    return 0;
-                }
-
-                var newList = new List<string> { line1LastWord, line2LastWord }.OrderByDescending(word => word, StringComparer.CurrentCulture).ToList();
-                return newList.IndexOf(line1LastWord) == 0 ? -1 : 1;
+                return string.Compare(line1LastWord, line2LastWord, StringComparison.CurrentCulture) * -1;
             });
             text = string.Join('\r', lines);
 

--- a/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
@@ -646,8 +646,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 return;
             }
 
-            var lines = text.Split('\r').ToList();
-            lines.Sort(StringComparer.CurrentCulture);
+            IOrderedEnumerable<string> lines = text.Split('\r').OrderBy(line => line, StringComparer.CurrentCulture);
             text = string.Join('\r', lines);
 
             lock (_lockObject)
@@ -672,9 +671,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 return;
             }
 
-            var lines = text.Split('\r').ToList();
-            lines.Sort(StringComparer.CurrentCulture);
-            lines.Reverse();
+            IOrderedEnumerable<string> lines = text.Split('\r').OrderByDescending(line => line, StringComparer.CurrentCulture);
             text = string.Join('\r', lines);
 
             lock (_lockObject)
@@ -710,8 +707,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                     return 0;
                 }
 
-                var newList = new List<string> { line1LastWord, line2LastWord };
-                newList.Sort(StringComparer.CurrentCulture);
+                var newList = new List<string> { line1LastWord, line2LastWord }.OrderBy(word => word).ToList();
                 return newList.IndexOf(line1LastWord) == 0 ? -1 : 1;
             });
             text = string.Join('\r', lines);
@@ -749,11 +745,9 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                     return 0;
                 }
 
-                var newList = new List<string> { line1LastWord, line2LastWord };
-                newList.Sort(StringComparer.CurrentCulture);
+                var newList = new List<string> { line1LastWord, line2LastWord }.OrderByDescending(word => word, StringComparer.CurrentCulture).ToList();
                 return newList.IndexOf(line1LastWord) == 0 ? -1 : 1;
             });
-            lines.Reverse();
             text = string.Join('\r', lines);
 
             lock (_lockObject)
@@ -778,8 +772,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 return;
             }
 
-            var lines = text.Split('\r').ToList();
-            lines.Reverse();
+            IEnumerable<string> lines = text.Split('\r').Reverse();
             text = string.Join('\r', lines);
 
             lock (_lockObject)
@@ -804,7 +797,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 return;
             }
 
-            var lines = text.Split('\r').OrderBy(_ => _random.Next());
+            IOrderedEnumerable<string> lines = text.Split('\r').OrderBy(_ => _random.Next());
             text = string.Join('\r', lines);
 
             lock (_lockObject)

--- a/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
@@ -181,12 +181,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
 
         private void ExecuteOriginalCaseCommand()
         {
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = _textBackup;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(_textBackup);
         }
 
         #endregion
@@ -226,12 +221,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 }
             }
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = new string(sentenceCaseString);
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(new string(sentenceCaseString));
         }
 
         #endregion
@@ -242,12 +232,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
 
         private void ExecuteLowerCaseCommand()
         {
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = _textBackup?.ToLowerInvariant();
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(_textBackup?.ToLowerInvariant());
         }
 
         #endregion
@@ -258,12 +243,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
 
         private void ExecuteUpperCaseCommand()
         {
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = _textBackup?.ToUpperInvariant();
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(_textBackup?.ToUpperInvariant());
         }
 
         #endregion
@@ -293,12 +273,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 }
             }
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = new string(titleCaseString);
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(new string(titleCaseString));
         }
 
         #endregion
@@ -347,12 +322,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 }
             }
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = camelCaseStringBuilder.ToString();
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(camelCaseStringBuilder.ToString());
         }
 
         #endregion
@@ -397,12 +367,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 }
             }
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = pascalCaseStringBuilder.ToString();
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(pascalCaseStringBuilder.ToString());
         }
 
         #endregion
@@ -421,12 +386,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
 
             string? snakeCase = SnakeConstantKebabCobolCaseConverter(text, '_', isUpperCase: false);
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = snakeCase;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(snakeCase);
         }
 
         #endregion
@@ -445,12 +405,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
 
             string? constantCase = SnakeConstantKebabCobolCaseConverter(text, '_', isUpperCase: true);
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = constantCase;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(constantCase);
         }
 
         #endregion
@@ -469,12 +424,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
 
             string? kebabCase = SnakeConstantKebabCobolCaseConverter(text, '-', isUpperCase: false);
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = kebabCase;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(kebabCase);
         }
 
         #endregion
@@ -493,12 +443,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
 
             string? cobolCase = SnakeConstantKebabCobolCaseConverter(text, '-', isUpperCase: true);
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = cobolCase;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(cobolCase);
         }
 
         #endregion
@@ -549,13 +494,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 }
             }
 
-
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = snakeCaseStringBuilder.ToString();
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(snakeCaseStringBuilder.ToString());
         }
 
         #endregion
@@ -587,12 +526,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 lowerCase = !lowerCase;
             }
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = new string(titleCaseString);
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(new string(titleCaseString));
         }
 
         #endregion
@@ -624,12 +558,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 lowerCase = !lowerCase;
             }
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = new string(titleCaseString);
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(new string(titleCaseString));
         }
 
         #endregion
@@ -649,12 +578,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             IOrderedEnumerable<string> lines = text.Split('\r').OrderBy(line => line, StringComparer.CurrentCulture);
             text = string.Join('\r', lines);
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = text;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(text);
         }
 
         #endregion
@@ -674,12 +598,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             IOrderedEnumerable<string> lines = text.Split('\r').OrderByDescending(line => line, StringComparer.CurrentCulture);
             text = string.Join('\r', lines);
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = text;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(text);
         }
 
         #endregion
@@ -706,12 +625,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             });
             text = string.Join('\r', lines);
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = text;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(text);
         }
 
         #endregion
@@ -738,12 +652,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             });
             text = string.Join('\r', lines);
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = text;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(text);
         }
 
         #endregion
@@ -763,12 +672,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             IEnumerable<string> lines = text.Split('\r').Reverse();
             text = string.Join('\r', lines);
 
-            lock (_lockObject)
-            {
-                _forbidBackup = true;
-                Text = text;
-                _forbidBackup = false;
-            }
+            SetTextWithoutBackup(text);
         }
 
         #endregion
@@ -788,6 +692,13 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             IOrderedEnumerable<string> lines = text.Split('\r').OrderBy(_ => _random.Next());
             text = string.Join('\r', lines);
 
+            SetTextWithoutBackup(text);
+        }
+
+        #endregion
+
+        private void SetTextWithoutBackup(string? text)
+        {
             lock (_lockObject)
             {
                 _forbidBackup = true;
@@ -795,8 +706,6 @@ namespace DevToys.ViewModels.Tools.StringUtilities
                 _forbidBackup = false;
             }
         }
-
-        #endregion
 
         private string SnakeConstantKebabCobolCaseConverter(string text, char spaceReplacement, bool isUpperCase)
         {

--- a/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
@@ -23,6 +23,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
         private static readonly object _lockObject = new();
 
         private readonly IMarketingService _marketingService;
+        private readonly Random _random;
 
         private bool _toolSuccessfullyWorked;
         private bool _forbidBackup;
@@ -143,6 +144,7 @@ namespace DevToys.ViewModels.Tools.StringUtilities
         public StringUtilitiesToolViewModel(IMarketingService marketingService)
         {
             _marketingService = marketingService;
+            _random = new Random();
             OriginalCaseCommand = new RelayCommand(ExecuteOriginalCaseCommand, CanExecuteOriginalCaseCommand);
             SentenceCaseCommand = new RelayCommand(ExecuteSentenceCaseCommand);
             LowerCaseCommand = new RelayCommand(ExecuteLowerCaseCommand);
@@ -157,6 +159,12 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             TrainCaseCommand = new RelayCommand(ExecuteTrainCaseCommand);
             AlternatingCaseCommand = new RelayCommand(ExecuteAlternatingCaseCommand);
             InverseCaseCommand = new RelayCommand(ExecuteInverseCaseCommand);
+            AlphabetizeCommand = new RelayCommand(ExecuteAlphabetizeCommand);
+            ReverseAlphabetizeCommand = new RelayCommand(ExecuteReverseAlphabetizeCommand);
+            AlphabetizeLastCommand = new RelayCommand(ExecuteAlphabetizeLastCommand);
+            ReverseAlphabetizeLastCommand = new RelayCommand(ExecuteReverseAlphabetizeLastCommand);
+            ReverseCommand = new RelayCommand(ExecuteReverseCommand);
+            RandomizeCommand = new RelayCommand(ExecuteRandomizeCommand);
 
             QueueSelectionStatisticCalculation();
             QueueTextStatisticCalculation();
@@ -620,6 +628,189 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             {
                 _forbidBackup = true;
                 Text = new string(titleCaseString);
+                _forbidBackup = false;
+            }
+        }
+
+        #endregion
+
+        #region AlphabetizeCommand
+
+        public IRelayCommand AlphabetizeCommand { get; }
+
+        private void ExecuteAlphabetizeCommand()
+        {
+            string? text = _textBackup;
+            if (text is null)
+            {
+                return;
+            }
+
+            var lines = text.Split('\r').ToList();
+            lines.Sort(StringComparer.CurrentCulture);
+            text = string.Join('\r', lines);
+
+            lock (_lockObject)
+            {
+                _forbidBackup = true;
+                Text = text;
+                _forbidBackup = false;
+            }
+        }
+
+        #endregion
+
+        #region ReverseAlphabetizeCommand
+
+        public IRelayCommand ReverseAlphabetizeCommand { get; }
+
+        private void ExecuteReverseAlphabetizeCommand()
+        {
+            string? text = _textBackup;
+            if (text is null)
+            {
+                return;
+            }
+
+            var lines = text.Split('\r').ToList();
+            lines.Sort(StringComparer.CurrentCulture);
+            lines.Reverse();
+            text = string.Join('\r', lines);
+
+            lock (_lockObject)
+            {
+                _forbidBackup = true;
+                Text = text;
+                _forbidBackup = false;
+            }
+        }
+
+        #endregion
+
+        #region AlphabetizeLastCommand
+
+        public IRelayCommand AlphabetizeLastCommand { get; }
+
+        private void ExecuteAlphabetizeLastCommand()
+        {
+            string? text = _textBackup;
+            if (text is null)
+            {
+                return;
+            }
+
+            var lines = text.Split('\r').ToList();
+            lines.Sort((line1, line2) =>
+            {
+                string? line1LastWord = line1.Split(' ', ',').LastOrDefault();
+                string? line2LastWord = line2.Split(' ', ',').LastOrDefault();
+
+                if (string.Equals(line1LastWord, line2LastWord, StringComparison.CurrentCulture))
+                {
+                    return 0;
+                }
+
+                var newList = new List<string> { line1LastWord, line2LastWord };
+                newList.Sort(StringComparer.CurrentCulture);
+                return newList.IndexOf(line1LastWord) == 0 ? -1 : 1;
+            });
+            text = string.Join('\r', lines);
+
+            lock (_lockObject)
+            {
+                _forbidBackup = true;
+                Text = text;
+                _forbidBackup = false;
+            }
+        }
+
+        #endregion
+
+        #region ReverseAlphabetizeLastCommand
+
+        public IRelayCommand ReverseAlphabetizeLastCommand { get; }
+
+        private void ExecuteReverseAlphabetizeLastCommand()
+        {
+            string? text = _textBackup;
+            if (text is null)
+            {
+                return;
+            }
+
+            var lines = text.Split('\r').ToList();
+            lines.Sort((line1, line2) =>
+            {
+                string? line1LastWord = line1.Split(' ', ',').LastOrDefault();
+                string? line2LastWord = line2.Split(' ', ',').LastOrDefault();
+
+                if (string.Equals(line1LastWord, line2LastWord, StringComparison.CurrentCulture))
+                {
+                    return 0;
+                }
+
+                var newList = new List<string> { line1LastWord, line2LastWord };
+                newList.Sort(StringComparer.CurrentCulture);
+                return newList.IndexOf(line1LastWord) == 0 ? -1 : 1;
+            });
+            lines.Reverse();
+            text = string.Join('\r', lines);
+
+            lock (_lockObject)
+            {
+                _forbidBackup = true;
+                Text = text;
+                _forbidBackup = false;
+            }
+        }
+
+        #endregion
+
+        #region ReverseCommand
+
+        public IRelayCommand ReverseCommand { get; }
+
+        private void ExecuteReverseCommand()
+        {
+            string? text = _textBackup;
+            if (text is null)
+            {
+                return;
+            }
+
+            var lines = text.Split('\r').ToList();
+            lines.Reverse();
+            text = string.Join('\r', lines);
+
+            lock (_lockObject)
+            {
+                _forbidBackup = true;
+                Text = text;
+                _forbidBackup = false;
+            }
+        }
+
+        #endregion
+
+        #region RandomizeCommand
+
+        public IRelayCommand RandomizeCommand { get; }
+
+        private void ExecuteRandomizeCommand()
+        {
+            string? text = _textBackup;
+            if (text is null)
+            {
+                return;
+            }
+
+            var lines = text.Split('\r').OrderBy(_ => _random.Next());
+            text = string.Join('\r', lines);
+
+            lock (_lockObject)
+            {
+                _forbidBackup = true;
+                Text = text;
                 _forbidBackup = false;
             }
         }

--- a/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Text/StringUtilities/StringUtilitiesToolViewModel.cs
@@ -618,8 +618,8 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             var lines = text.Split('\r').ToList();
             lines.Sort((line1, line2) =>
             {
-                string? line1LastWord = line1.Split(' ', ',').LastOrDefault();
-                string? line2LastWord = line2.Split(' ', ',').LastOrDefault();
+                string line1LastWord = new(line1.Reverse().TakeWhile(char.IsLetterOrDigit).Reverse().ToArray());
+                string line2LastWord = new(line2.Reverse().TakeWhile(char.IsLetterOrDigit).Reverse().ToArray());
 
                 return string.Compare(line1LastWord, line2LastWord, StringComparison.CurrentCulture);
             });
@@ -645,8 +645,8 @@ namespace DevToys.ViewModels.Tools.StringUtilities
             var lines = text.Split('\r').ToList();
             lines.Sort((line1, line2) =>
             {
-                string? line1LastWord = line1.Split(' ', ',').LastOrDefault();
-                string? line2LastWord = line2.Split(' ', ',').LastOrDefault();
+                string line1LastWord = new(line1.Reverse().TakeWhile(char.IsLetterOrDigit).Reverse().ToArray());
+                string line2LastWord = new(line2.Reverse().TakeWhile(char.IsLetterOrDigit).Reverse().ToArray());
 
                 return string.Compare(line1LastWord, line2LastWord, StringComparison.CurrentCulture) * -1;
             });

--- a/src/dev/impl/DevToys/Views/Tools/Text/StringUtilities/StringUtilitiesToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/StringUtilities/StringUtilitiesToolPage.xaml
@@ -43,6 +43,7 @@
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
@@ -52,7 +53,7 @@
         </Grid.ColumnDefinitions>
 
         <controls:CustomTextBox
-            Grid.Row="1"
+            Grid.Row="2"
             Grid.Column="0"
             Header="{x:Bind ViewModel.Strings.String}"
             AcceptsReturn="True"
@@ -86,10 +87,27 @@
             </toolkit:WrapPanel>
         </StackPanel>
 
+        <StackPanel
+            Grid.Row="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Spacing="4">
+            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Sort}" />
+
+            <toolkit:WrapPanel VerticalSpacing="4" HorizontalSpacing="4">
+                <Button Content="{x:Bind ViewModel.Strings.Alphabetize}" Command="{x:Bind ViewModel.AlphabetizeCommand}"/>
+                <Button Content="{x:Bind ViewModel.Strings.ReverseAlphabetize}" Command="{x:Bind ViewModel.ReverseAlphabetizeCommand}"/>
+                <Button Content="{x:Bind ViewModel.Strings.AlphabetizeLast}" Command="{x:Bind ViewModel.AlphabetizeLastCommand}"/>
+                <Button Content="{x:Bind ViewModel.Strings.ReverseAlphabetizeLast}" Command="{x:Bind ViewModel.ReverseAlphabetizeLastCommand}"/>
+                <Button Content="{x:Bind ViewModel.Strings.Reverse}" Command="{x:Bind ViewModel.ReverseCommand}"/>
+                <Button Content="{x:Bind ViewModel.Strings.Randomize}" Command="{x:Bind ViewModel.RandomizeCommand}"/>
+            </toolkit:WrapPanel>
+        </StackPanel>
+
         <Grid
             x:Name="StatisticsGrid"
             Style="{StaticResource CardStyle}"
-            Grid.Row="1"
+            Grid.Row="2"
             Grid.Column="1"
             Margin="0,42,0,0">
             <StackPanel

--- a/src/tests/DevToys.Tests/Providers/Tools/StringUtilitiesTests.cs
+++ b/src/tests/DevToys.Tests/Providers/Tools/StringUtilitiesTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using DevToys.ViewModels.Tools.StringUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -528,6 +530,127 @@ PrOgRaMmAbLe iN C#, C++, vIsUaL BaSiC, aNd jAvAsCrIpT. fOr uI, uSe wInUi, XaMl, 
 lEt's lOoK At tHeSe iN MoRe dEtAiL.";
 
             Assert.AreEqual(expectedResult, viewModel.Text);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", "")]
+        [DataRow("c\ra\rb", "a\rb\rc")]
+        [DataRow("C\rA\rB", "A\rB\rC")]
+        [DataRow("c\rA\rB", "A\rB\rc")]
+        [DataRow("c\ra\rb\r3\r1\r2", "1\r2\r3\ra\rb\rc")]
+        [DataRow("Steve Adams\rAdam,Smith\rBob Barker\rXander", "Adam,Smith\rBob Barker\rSteve Adams\rXander")]
+        public void Alphabetize(string input, string expectedResult)
+        {
+            StringUtilitiesToolViewModel viewModel = ExportProvider.Import<StringUtilitiesToolViewModel>();
+
+            viewModel.Text = input;
+
+            viewModel.AlphabetizeCommand.Execute(null);
+
+            Assert.AreEqual(expectedResult, viewModel.Text);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", "")]
+        [DataRow("c\ra\rb", "c\rb\ra")]
+        [DataRow("C\rA\rB", "C\rB\rA")]
+        [DataRow("c\rA\rB", "c\rB\rA")]
+        [DataRow("c\ra\rb\r3\r1\r2", "c\rb\ra\r3\r2\r1")]
+        [DataRow("Steve Adams\rAdam,Smith\rBob Barker\rXander", "Xander\rSteve Adams\rBob Barker\rAdam,Smith")]
+        public void ReverseAlphabetize(string input, string expectedResult)
+        {
+            StringUtilitiesToolViewModel viewModel = ExportProvider.Import<StringUtilitiesToolViewModel>();
+
+            viewModel.Text = input;
+
+            viewModel.ReverseAlphabetizeCommand.Execute(null);
+
+            Assert.AreEqual(expectedResult, viewModel.Text);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", "")]
+        [DataRow("c\ra\rb", "a\rb\rc")]
+        [DataRow("C\rA\rB", "A\rB\rC")]
+        [DataRow("c\rA\rB", "A\rB\rc")]
+        [DataRow("c\ra\rb\r3\r1\r2", "1\r2\r3\ra\rb\rc")]
+        [DataRow("Steve Adams\rAdam,Smith\rBob Barker\rXander", "Steve Adams\rBob Barker\rAdam,Smith\rXander")]
+        public void AlphabetizeLast(string input, string expectedResult)
+        {
+            StringUtilitiesToolViewModel viewModel = ExportProvider.Import<StringUtilitiesToolViewModel>();
+
+            viewModel.Text = input;
+
+            viewModel.AlphabetizeLastCommand.Execute(null);
+
+            Assert.AreEqual(expectedResult, viewModel.Text);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", "")]
+        [DataRow("c\ra\rb", "c\rb\ra")]
+        [DataRow("C\rA\rB", "C\rB\rA")]
+        [DataRow("c\rA\rB", "c\rB\rA")]
+        [DataRow("c\ra\rb\r3\r1\r2", "c\rb\ra\r3\r2\r1")]
+        [DataRow("Steve Adams\rAdam,Smith\rBob Barker\rXander", "Xander\rAdam,Smith\rBob Barker\rSteve Adams")]
+        public void ReverseAlphabetizeLast(string input, string expectedResult)
+        {
+            StringUtilitiesToolViewModel viewModel = ExportProvider.Import<StringUtilitiesToolViewModel>();
+
+            viewModel.Text = input;
+
+            viewModel.ReverseAlphabetizeLastCommand.Execute(null);
+
+            Assert.AreEqual(expectedResult, viewModel.Text);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", "")]
+        [DataRow("c\ra\rb", "b\ra\rc")]
+        [DataRow("C\rA\rB", "B\rA\rC")]
+        [DataRow("c\rA\rB", "B\rA\rc")]
+        [DataRow("c\ra\rb\r3\r1\r2", "2\r1\r3\rb\ra\rc")]
+        [DataRow("Steve Adams\rAdam,Smith\rBob Barker\rXander", "Xander\rBob Barker\rAdam,Smith\rSteve Adams")]
+        public void Reverse(string input, string expectedResult)
+        {
+            StringUtilitiesToolViewModel viewModel = ExportProvider.Import<StringUtilitiesToolViewModel>();
+
+            viewModel.Text = input;
+
+            viewModel.ReverseCommand.Execute(null);
+
+            Assert.AreEqual(expectedResult, viewModel.Text);
+        }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("c\ra\rb")]
+        [DataRow("C\rA\rB")]
+        [DataRow("c\rA\rB")]
+        [DataRow("c\ra\rb\r3\r1\r2")]
+        [DataRow("Steve Adams\rAdam,Smith\rBob Barker\rXander")]
+        public void Randomize(string input)
+        {
+            StringUtilitiesToolViewModel viewModel = ExportProvider.Import<StringUtilitiesToolViewModel>();
+
+            viewModel.Text = input;
+
+            viewModel.RandomizeCommand.Execute(null);
+
+            // Can't guarantee the order, just make sure everything is still there
+            string[] inputLines = input?.Split('\r') ?? Array.Empty<string>();
+            string[] outputLines = viewModel.Text?.Split('\r') ?? Array.Empty<string>();
+            Assert.AreEqual(inputLines.Length, outputLines.Length);
+            foreach (string inputLine in inputLines)
+            {
+                Assert.IsTrue(outputLines.Contains(inputLine));
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #232

## What is the new behavior?

Add the following functions to the string utilities tool. These operate on lines of text.

- Alphabetize
- Reverse alphabetize
- Alphabetize by last word
- Reverse alphabetize by last word
- Reverse
- Randomize

https://github.com/veler/DevToys/assets/7417301/9e31476f-dd56-4e01-8edf-d6b150d4d3b1
 
## Other information

All of the line splitting is done on CR (`\r`). I noticed that this is the line separator used for typed text and loaded files using any line endings (CR, LF,"or or CRLF). I don't really understand why, but it seems consistent.

For sorting by last word, I'm splitting on space and also comma (to accommodate CSV and last,first formatting).

It might be ever so slightly confusing that the "Original text" button is under the "Convert" heading. Maybe we could consider making it a highlighted/action button.

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)