### PR TITLE
Allow diff viewer to be expanded

### DIFF
--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -741,6 +741,11 @@ namespace DevToys
         public string Clear => _resources.GetString("Clear");
 
         /// <summary>
+        /// Gets the resource Collapse.
+        /// </summary>
+        public string Collapse => _resources.GetString("Collapse");
+
+        /// <summary>
         /// Gets the resource Copy.
         /// </summary>
         public string Copy => _resources.GetString("Copy");
@@ -754,6 +759,11 @@ namespace DevToys
         /// Gets the resource Delete.
         /// </summary>
         public string Delete => _resources.GetString("Delete");
+
+        /// <summary>
+        /// Gets the resource Expand.
+        /// </summary>
+        public string Expand => _resources.GetString("Expand");
 
         /// <summary>
         /// Gets the resource FileSelectorBrowseFiles.

--- a/src/dev/impl/DevToys/Strings/en-US/Common.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/Common.resw
@@ -123,6 +123,9 @@
   <data name="Clear" xml:space="preserve">
     <value>Clear</value>
   </data>
+  <data name="Collapse" xml:space="preserve">
+    <value>Collapse</value>
+  </data>
   <data name="Copy" xml:space="preserve">
     <value>Copy</value>
   </data>
@@ -131,6 +134,9 @@
   </data>
   <data name="Delete" xml:space="preserve">
     <value>Delete</value>
+  </data>
+  <data name="Expand" xml:space="preserve">
+    <value>Expand</value>
   </data>
   <data name="FileSelectorBrowseFiles" xml:space="preserve">
     <value>Browse files</value>

--- a/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml
+++ b/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml
@@ -65,6 +65,7 @@
                 x:DeferLoadStrategy="Lazy"
                 Visibility="Collapsed"
                 TabIndex="0"
+                Margin="8,0,0,0"
                 AutomationProperties.Name="{Binding Instance.Common.Paste, Mode=OneTime, Source={StaticResource LanguageManager}}"
                 Click="PasteButton_Click">
                 <StackPanel Orientation="Horizontal" Spacing="4">

--- a/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml
+++ b/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml
@@ -50,6 +50,17 @@
             Margin="0,0,0,8"
             AutomationProperties.LabeledBy="{x:Bind HeaderTextBlock}">
             <Button
+                x:Name="ExpandButton"
+                x:DeferLoadStrategy="Lazy"
+                Visibility="Visible"
+                TabIndex="0"
+                Margin="8,0,0,0"
+                ToolTipService.ToolTip="{Binding Instance.Common.Expand, Mode=OneTime, Source={StaticResource LanguageManager}}"
+                AutomationProperties.Name="{Binding Instance.Common.Expand, Mode=OneTime, Source={StaticResource LanguageManager}}"
+                Click="ExpandButton_Click">
+                <FontIcon x:Name="ExpandButtonIcon" Glyph="&#xF15F;"/>
+            </Button>
+            <Button
                 x:Name="PasteButton"
                 x:DeferLoadStrategy="Lazy"
                 Visibility="Collapsed"

--- a/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml.cs
+++ b/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml.cs
@@ -189,6 +189,23 @@ namespace DevToys.UI.Controls
             set => SetValue(InlineDiffViewModeProperty, value);
         }
 
+        public static readonly DependencyProperty AllowExpandProperty
+            = DependencyProperty.Register(
+                nameof(AllowExpand),
+                typeof(bool),
+                typeof(CodeEditor),
+                new PropertyMetadata(false));
+
+        public bool AllowExpand
+        {
+            get => (bool)GetValue(AllowExpandProperty);
+            set => SetValue(AllowExpandProperty, value);
+        }
+
+        public bool IsExpanded { get; private set; }
+
+        public event EventHandler? ExpandedChanged;
+
         public CodeEditor()
         {
             SettingsProvider = MefComposer.Provider.Import<ISettingsProvider>();
@@ -273,6 +290,16 @@ namespace DevToys.UI.Controls
 
                 ApplySettings();
             }
+        }
+
+        private Button GetExpandButton()
+        {
+            return (Button)(ExpandButton ?? FindName(nameof(ExpandButton)));
+        }
+
+        private FontIcon GetExpandButtonIcon()
+        {
+            return (FontIcon)(ExpandButtonIcon ?? FindName(nameof(ExpandButtonIcon)));
         }
 
         private Button GetCopyButton()
@@ -455,6 +482,28 @@ namespace DevToys.UI.Controls
                     OpenFileButton.Visibility = Visibility.Collapsed;
                     ClearButton.Visibility = Visibility.Collapsed;
                 }
+            }
+
+            if (AllowExpand)
+            {
+                GetExpandButton().Visibility = Visibility.Visible;
+            }
+        }
+
+        private void ExpandButton_Click(object _, RoutedEventArgs e)
+        {
+            IsExpanded = !IsExpanded;
+            ExpandedChanged?.Invoke(this, EventArgs.Empty);
+
+            if (IsExpanded)
+            {
+                GetExpandButtonIcon().Glyph = "\uF165";
+                ToolTipService.SetToolTip(GetExpandButton(), LanguageManager.Instance.Common.Collapse);
+            }
+            else
+            {
+                GetExpandButtonIcon().Glyph = "\uF15F";
+                ToolTipService.SetToolTip(GetExpandButton(), LanguageManager.Instance.Common.Expand);
             }
         }
 

--- a/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml
+++ b/src/dev/impl/DevToys/UI/Controls/CustomTextBox.xaml
@@ -50,6 +50,16 @@
             Margin="0,0,0,8"
             AutomationProperties.LabeledBy="{Binding ElementName=HeaderTextBlock}">
             <Button
+                x:Name="ExpandButton"
+                x:DeferLoadStrategy="Lazy"
+                Visibility="Visible"
+                TabIndex="0"
+                ToolTipService.ToolTip="{Binding Instance.Common.Expand, Mode=OneTime, Source={StaticResource LanguageManager}}"
+                AutomationProperties.Name="{Binding Instance.Common.Expand, Mode=OneTime, Source={StaticResource LanguageManager}}"
+                Click="ExpandButton_Click">
+                <FontIcon x:Name="ExpandButtonIcon" Glyph="&#xF15F;"/>
+            </Button>
+            <Button
                 x:Name="RefreshButton"
                 x:DeferLoadStrategy="Lazy"
                 TabIndex="2"

--- a/src/dev/impl/DevToys/Views/Tools/Converters/JsonYaml/JsonYamlToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Converters/JsonYaml/JsonYamlToolPage.xaml
@@ -33,113 +33,118 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        
+
         <Grid.ChildrenTransitions>
             <TransitionCollection>
                 <EntranceThemeTransition IsStaggeringEnabled="True" FromVerticalOffset="50"/>
             </TransitionCollection>
         </Grid.ChildrenTransitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-
-        <StackPanel
-            Grid.Row="0"
-            Spacing="4">
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
-
-            <controls:ExpandableSettingControl
-                Title="{x:Bind ViewModel.Strings.ConversionTitle}"
-                Description="{x:Bind ViewModel.Strings.ConversionDescription}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF18D;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ComboBox
-                    SelectedValuePath="Tag"
-                    SelectedValue="{x:Bind ViewModel.ConversionMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                    <ComboBoxItem Tag="JsonToYaml" Content="{x:Bind ViewModel.Strings.JsonToYaml}"/>
-                    <ComboBoxItem Tag="YamlToJson" Content="{x:Bind ViewModel.Strings.YamlToJson}"/>
-                </ComboBox>
-            </controls:ExpandableSettingControl>
-
-            <controls:ExpandableSettingControl
-                x:Name="IndentationSetting"
-                Title="{x:Bind ViewModel.Strings.Indentation}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF6F8;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ComboBox
-                    ItemsSource="{x:Bind ViewModel.Indentations}"
-                    DisplayMemberPath="DisplayName"
-                    SelectedValue="{x:Bind ViewModel.IndentationMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                </ComboBox>
-            </controls:ExpandableSettingControl>
-        </StackPanel>
-
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition MinWidth="100"/>
-                <ColumnDefinition Width="16"/>
-                <ColumnDefinition MinWidth="100"/>
-            </Grid.ColumnDefinitions>
+        <Grid x:Name="MainGrid" RowSpacing="12">
             <Grid.RowDefinitions>
-                <RowDefinition MinHeight="100"/>
-                <RowDefinition Height="16"/>
-                <RowDefinition MinHeight="100"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <controls:CodeEditor
-                x:Name="InputCodeEditor"
-                Grid.Column="0"
+            <StackPanel
                 Grid.Row="0"
-                Grid.RowSpan="3"
-                Header="{x:Bind ViewModel.Strings.Input}"
-                Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                CodeLanguage="{x:Bind ViewModel.InputValueLanguage, Mode=OneWay}"/>
+                Spacing="4">
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
 
-            <toolkit:GridSplitter
-                x:Name="VerticalGridSplitter"
-                Grid.Column="1"
-                Grid.Row="0"
-                Grid.RowSpan="3"
-                Width="16"
-                Margin="0,42,0,0"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Columns">
-                <toolkit:GridSplitter.Element>
-                    <FontIcon
-                        Glyph="&#xFD55;"
-                        FontSize="13"/>
-                </toolkit:GridSplitter.Element>
-            </toolkit:GridSplitter>
+                <controls:ExpandableSettingControl
+                    Title="{x:Bind ViewModel.Strings.ConversionTitle}"
+                    Description="{x:Bind ViewModel.Strings.ConversionDescription}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF18D;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ComboBox
+                        SelectedValuePath="Tag"
+                        SelectedValue="{x:Bind ViewModel.ConversionMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <ComboBoxItem Tag="JsonToYaml" Content="{x:Bind ViewModel.Strings.JsonToYaml}"/>
+                        <ComboBoxItem Tag="YamlToJson" Content="{x:Bind ViewModel.Strings.YamlToJson}"/>
+                    </ComboBox>
+                </controls:ExpandableSettingControl>
 
-            <toolkit:GridSplitter
-                x:Name="HorizontalGridSplitter"
-                Grid.Row="1"
-                Grid.Column="0"
-                Grid.ColumnSpan="3"
-                Height="16"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Rows"
-                Visibility="Collapsed">
-                <toolkit:GridSplitter.Element>
-                    <FontIcon
-                        Glyph="&#xFD52;"
-                        FontSize="13"/>
-                </toolkit:GridSplitter.Element>
-            </toolkit:GridSplitter>
+                <controls:ExpandableSettingControl
+                    x:Name="IndentationSetting"
+                    Title="{x:Bind ViewModel.Strings.Indentation}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF6F8;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ComboBox
+                        ItemsSource="{x:Bind ViewModel.Indentations}"
+                        DisplayMemberPath="DisplayName"
+                        SelectedValue="{x:Bind ViewModel.IndentationMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    </ComboBox>
+                </controls:ExpandableSettingControl>
+            </StackPanel>
 
-            <controls:CodeEditor
-                x:Name="OutputCodeEditor"
-                Grid.Column="2"
-                Grid.Row="0"
-                Grid.RowSpan="3"
-                IsReadOnly="True"
-                Header="{x:Bind ViewModel.Strings.Output}"
-                Text="{x:Bind ViewModel.OutputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                CodeLanguage="{x:Bind ViewModel.OutputValueLanguage, Mode=OneWay}"/>
+            <Grid Grid.Row="1" x:Name="InputOutputGrid">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="100"/>
+                    <ColumnDefinition Width="16"/>
+                    <ColumnDefinition MinWidth="100"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition MinHeight="100"/>
+                    <RowDefinition Height="16"/>
+                    <RowDefinition MinHeight="100"/>
+                </Grid.RowDefinitions>
+
+                <controls:CodeEditor
+                    x:Name="InputCodeEditor"
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Header="{x:Bind ViewModel.Strings.Input}"
+                    Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    CodeLanguage="{x:Bind ViewModel.InputValueLanguage, Mode=OneWay}"/>
+
+                <toolkit:GridSplitter
+                    x:Name="VerticalGridSplitter"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Width="16"
+                    Margin="0,42,0,0"
+                    ResizeBehavior="BasedOnAlignment"
+                    ResizeDirection="Columns">
+                    <toolkit:GridSplitter.Element>
+                        <FontIcon
+                            Glyph="&#xFD55;"
+                            FontSize="13"/>
+                    </toolkit:GridSplitter.Element>
+                </toolkit:GridSplitter>
+
+                <toolkit:GridSplitter
+                    x:Name="HorizontalGridSplitter"
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="3"
+                    Height="16"
+                    ResizeBehavior="BasedOnAlignment"
+                    ResizeDirection="Rows"
+                    Visibility="Collapsed">
+                    <toolkit:GridSplitter.Element>
+                        <FontIcon
+                            Glyph="&#xFD52;"
+                            FontSize="13"/>
+                    </toolkit:GridSplitter.Element>
+                </toolkit:GridSplitter>
+
+                <controls:CodeEditor
+                    x:Name="OutputCodeEditor"
+                    Grid.Column="2"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    IsReadOnly="True"
+                    Header="{x:Bind ViewModel.Strings.Output}"
+                    Text="{x:Bind ViewModel.OutputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    CodeLanguage="{x:Bind ViewModel.OutputValueLanguage, Mode=OneWay}"
+                    AllowExpand="True"
+                    ExpandedChanged="OutputCodeEditor_ExpandedChanged"/>
+            </Grid>
         </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Converters/JsonYaml/JsonYamlToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Converters/JsonYaml/JsonYamlToolPage.xaml.cs
@@ -61,5 +61,21 @@ namespace DevToys.Views.Tools.JsonYaml
 
             base.OnNavigatedTo(e);
         }
+
+        private void OutputCodeEditor_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (OutputCodeEditor.IsExpanded)
+            {
+                InputOutputGrid.Children.Remove(OutputCodeEditor);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputCodeEditor);
+            }
+            else
+            {
+                ExpandedGrid.Children.Remove(OutputCodeEditor);
+                InputOutputGrid.Children.Add(OutputCodeEditor);
+                MainGrid.Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/Base64TextEncoderDecoder/Base64EncoderDecoderToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/Base64TextEncoderDecoder/Base64EncoderDecoderToolPage.xaml
@@ -28,58 +28,63 @@
                 <EntranceThemeTransition IsStaggeringEnabled="True" FromVerticalOffset="50"/>
             </TransitionCollection>
         </Grid.ChildrenTransitions>
-        
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
 
-        <StackPanel Spacing="4" Grid.Row="0" >
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
-            <controls:ExpandableSettingControl
-                Title="{x:Bind ViewModel.Strings.ConversionTitle}"
-                Description="{x:Bind ViewModel.Strings.ConversionDescription}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF18D;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ToggleSwitch 
-                    Style="{StaticResource RightAlignedToggleSwitchStyle}"
-                    OnContent="{x:Bind ViewModel.Strings.ConversionEncode}" OffContent="{x:Bind ViewModel.Strings.ConversionDecode}"
-                    IsOn="{x:Bind ViewModel.IsEncodeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            </controls:ExpandableSettingControl>
-            <controls:ExpandableSettingControl
-                x:Name="EncodingSetting"
-                Title="{x:Bind ViewModel.Strings.EncodingTitle}"
-                Description="{x:Bind ViewModel.Strings.EncodingDescription}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF7E4;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ComboBox
-                    SelectedValuePath="Tag"
-                    SelectedValue="{x:Bind ViewModel.EncodingMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                    <ComboBoxItem Tag="UTF-8" Content="{x:Bind ViewModel.Strings.Utf8}" />
-                    <ComboBoxItem Tag="ASCII" Content="{x:Bind ViewModel.Strings.Ascii}" />
-                </ComboBox>
-            </controls:ExpandableSettingControl>
-        </StackPanel>
+        <Grid x:Name="MainGrid" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-        <controls:CustomTextBox
-            Grid.Row="1"
-            MinHeight="150"
-            AcceptsReturn="True"
-            IsRichTextEdit="True"
-            Header="{x:Bind ViewModel.Strings.InputTitle}"
-            Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            <StackPanel Spacing="4" Grid.Row="0" >
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
+                <controls:ExpandableSettingControl
+                    Title="{x:Bind ViewModel.Strings.ConversionTitle}"
+                    Description="{x:Bind ViewModel.Strings.ConversionDescription}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF18D;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ToggleSwitch 
+                        Style="{StaticResource RightAlignedToggleSwitchStyle}"
+                        OnContent="{x:Bind ViewModel.Strings.ConversionEncode}" OffContent="{x:Bind ViewModel.Strings.ConversionDecode}"
+                        IsOn="{x:Bind ViewModel.IsEncodeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </controls:ExpandableSettingControl>
+                <controls:ExpandableSettingControl
+                    x:Name="EncodingSetting"
+                    Title="{x:Bind ViewModel.Strings.EncodingTitle}"
+                    Description="{x:Bind ViewModel.Strings.EncodingDescription}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF7E4;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ComboBox
+                        SelectedValuePath="Tag"
+                        SelectedValue="{x:Bind ViewModel.EncodingMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <ComboBoxItem Tag="UTF-8" Content="{x:Bind ViewModel.Strings.Utf8}" />
+                        <ComboBoxItem Tag="ASCII" Content="{x:Bind ViewModel.Strings.Ascii}" />
+                    </ComboBox>
+                </controls:ExpandableSettingControl>
+            </StackPanel>
 
-        <controls:CustomTextBox
-            Grid.Row="2"
-            MinHeight="150"
-            IsReadOnly="True"
-            AcceptsReturn="True"
-            IsRichTextEdit="True"
-            Header="{x:Bind ViewModel.Strings.OutputTitle}"
-            Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"/>
+            <controls:CustomTextBox
+                Grid.Row="1"
+                MinHeight="150"
+                AcceptsReturn="True"
+                IsRichTextEdit="True"
+                Header="{x:Bind ViewModel.Strings.InputTitle}"
+                Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
+            <controls:CustomTextBox
+                x:Name="OutputTextBox"
+                Grid.Row="2"
+                MinHeight="150"
+                IsReadOnly="True"
+                AcceptsReturn="True"
+                IsRichTextEdit="True"
+                Header="{x:Bind ViewModel.Strings.OutputTitle}"
+                Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
+                AllowExpand="True"
+                ExpandedChanged="OutputTextBox_ExpandedChanged"/>
+        </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/Base64TextEncoderDecoder/Base64EncoderDecoderToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/Base64TextEncoderDecoder/Base64EncoderDecoderToolPage.xaml.cs
@@ -52,5 +52,21 @@ namespace DevToys.Views.Tools.Base64EncoderDecoder
 
             base.OnNavigatedTo(e);
         }
+
+        private void OutputTextBox_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (OutputTextBox.IsExpanded)
+            {
+                MainGrid.Children.Remove(OutputTextBox);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputTextBox);
+            }
+            else
+            {
+                ExpandedGrid.Children.Remove(OutputTextBox);
+                MainGrid.Children.Add(OutputTextBox);
+                MainGrid.Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/GZipEncoderDecoder/GZipEncoderDecoderToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/GZipEncoderDecoder/GZipEncoderDecoderToolPage.xaml
@@ -16,42 +16,47 @@
             </TransitionCollection>
         </Grid.ChildrenTransitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+        <Grid x:Name="MainGrid" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-        <StackPanel Spacing="4" Grid.Row="0" >
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
-            <controls:ExpandableSettingControl
+            <StackPanel Spacing="4" Grid.Row="0" >
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
+                <controls:ExpandableSettingControl
+                    Grid.Row="1"
+                    Title="{x:Bind ViewModel.Strings.ConversionTitle}"
+                    Description="{x:Bind ViewModel.Strings.ConversionDescription}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF18D;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ToggleSwitch 
+                        Style="{StaticResource RightAlignedToggleSwitchStyle}"
+                        OnContent="{x:Bind ViewModel.Strings.ConversionCompress}" OffContent="{x:Bind ViewModel.Strings.ConversionDecompress}"
+                        IsOn="{x:Bind ViewModel.IsCompressMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </controls:ExpandableSettingControl>
+            </StackPanel>
+
+            <controls:CustomTextBox
                 Grid.Row="1"
-                Title="{x:Bind ViewModel.Strings.ConversionTitle}"
-                Description="{x:Bind ViewModel.Strings.ConversionDescription}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF18D;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ToggleSwitch 
-                    Style="{StaticResource RightAlignedToggleSwitchStyle}"
-                    OnContent="{x:Bind ViewModel.Strings.ConversionCompress}" OffContent="{x:Bind ViewModel.Strings.ConversionDecompress}"
-                    IsOn="{x:Bind ViewModel.IsCompressMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            </controls:ExpandableSettingControl>
-        </StackPanel>
+                MinHeight="150"
+                AcceptsReturn="True"
+                Header="{x:Bind ViewModel.Strings.InputTitle}"
+                Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <controls:CustomTextBox
-            Grid.Row="1"
-            MinHeight="150"
-            AcceptsReturn="True"
-            Header="{x:Bind ViewModel.Strings.InputTitle}"
-            Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <controls:CustomTextBox
-            Grid.Row="2"
-            MinHeight="150"
-            IsReadOnly="True"
-            AcceptsReturn="True"
-            Header="{x:Bind ViewModel.Strings.OutputTitle}"
-            Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"/>
-
+            <controls:CustomTextBox
+                x:Name="OutputTextBox"
+                Grid.Row="2"
+                MinHeight="150"
+                IsReadOnly="True"
+                AcceptsReturn="True"
+                Header="{x:Bind ViewModel.Strings.OutputTitle}"
+                Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
+                AllowExpand="True"
+                ExpandedChanged="OutputTextBox_ExpandedChanged"/>
+        </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/GZipEncoderDecoder/GZipEncoderDecoderToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/GZipEncoderDecoder/GZipEncoderDecoderToolPage.xaml.cs
@@ -52,5 +52,21 @@ namespace DevToys.Views.Tools.GZipEncoderDecoder
 
             base.OnNavigatedTo(e);
         }
+
+        private void OutputTextBox_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (OutputTextBox.IsExpanded)
+            {
+                MainGrid.Children.Remove(OutputTextBox);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputTextBox);
+            }
+            else
+            {
+                ExpandedGrid.Children.Remove(OutputTextBox);
+                MainGrid.Children.Add(OutputTextBox);
+                MainGrid.Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/HtmlEncoderDecoder/HtmlEncoderDecoderToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/HtmlEncoderDecoder/HtmlEncoderDecoderToolPage.xaml
@@ -16,42 +16,47 @@
             </TransitionCollection>
         </Grid.ChildrenTransitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+        <Grid x:Name="MainGrid" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-        <StackPanel Spacing="4" Grid.Row="0" >
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
-            <controls:ExpandableSettingControl
+            <StackPanel Spacing="4" Grid.Row="0" >
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
+                <controls:ExpandableSettingControl
+                    Grid.Row="1"
+                    Title="{x:Bind ViewModel.Strings.ConversionTitle}"
+                    Description="{x:Bind ViewModel.Strings.ConversionDescription}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF18D;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ToggleSwitch 
+                        Style="{StaticResource RightAlignedToggleSwitchStyle}"
+                        OnContent="{x:Bind ViewModel.Strings.ConversionEncode}" OffContent="{x:Bind ViewModel.Strings.ConversionDecode}"
+                        IsOn="{x:Bind ViewModel.IsEncodeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </controls:ExpandableSettingControl>
+            </StackPanel>
+
+            <controls:CustomTextBox
                 Grid.Row="1"
-                Title="{x:Bind ViewModel.Strings.ConversionTitle}"
-                Description="{x:Bind ViewModel.Strings.ConversionDescription}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF18D;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ToggleSwitch 
-                    Style="{StaticResource RightAlignedToggleSwitchStyle}"
-                    OnContent="{x:Bind ViewModel.Strings.ConversionEncode}" OffContent="{x:Bind ViewModel.Strings.ConversionDecode}"
-                    IsOn="{x:Bind ViewModel.IsEncodeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            </controls:ExpandableSettingControl>
-        </StackPanel>
+                MinHeight="150"
+                AcceptsReturn="True"
+                Header="{x:Bind ViewModel.Strings.InputTitle}"
+                Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <controls:CustomTextBox
-            Grid.Row="1"
-            MinHeight="150"
-            AcceptsReturn="True"
-            Header="{x:Bind ViewModel.Strings.InputTitle}"
-            Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <controls:CustomTextBox
-            Grid.Row="2"
-            MinHeight="150"
-            IsReadOnly="True"
-            AcceptsReturn="True"
-            Header="{x:Bind ViewModel.Strings.OutputTitle}"
-            Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"/>
-
+            <controls:CustomTextBox
+                x:Name="OutputTextBox"
+                Grid.Row="2"
+                MinHeight="150"
+                IsReadOnly="True"
+                AcceptsReturn="True"
+                Header="{x:Bind ViewModel.Strings.OutputTitle}"
+                Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
+                AllowExpand="True"
+                ExpandedChanged="OutputTextBox_ExpandedChanged"/>
+        </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/HtmlEncoderDecoder/HtmlEncoderDecoderToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/HtmlEncoderDecoder/HtmlEncoderDecoderToolPage.xaml.cs
@@ -52,5 +52,21 @@ namespace DevToys.Views.Tools.HtmlEncoderDecoder
 
             base.OnNavigatedTo(e);
         }
+
+        private void OutputTextBox_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (OutputTextBox.IsExpanded)
+            {
+                MainGrid.Children.Remove(OutputTextBox);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputTextBox);
+            }
+            else
+            {
+                ExpandedGrid.Children.Remove(OutputTextBox);
+                MainGrid.Children.Add(OutputTextBox);
+                MainGrid.Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
@@ -175,7 +175,9 @@
             Header="{x:Bind ViewModel.LocalizedStrings.JwtPayloadLabel}"
             Text="{x:Bind ViewModel.Payload, Mode=OneWay}"
             CodeLanguage="json"
-            IsReadOnly="True"/>
+            IsReadOnly="True"
+            AllowExpand="True"
+            ExpandedChanged="PayloadCodeEditor_ExpandedChanged"/>
         <Grid
             x:Name="SignatureGrid"
             Grid.Row="4"

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using System.Composition;
 using DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder;
 using Windows.UI.Xaml;
@@ -16,6 +17,11 @@ namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
                typeof(JwtDecoderControl),
                new PropertyMetadata(default(JwtDecoderControlViewModel)));
 
+
+        public event EventHandler? ExpandedChanged;
+
+        public bool IsExpanded { get; private set; }
+
         /// <summary>
         /// Gets the page's view model.
         /// </summary>
@@ -28,6 +34,22 @@ namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
         public JwtDecoderControl()
         {
             InitializeComponent();
+        }
+
+        private void PayloadCodeEditor_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            IsExpanded = !IsExpanded;
+
+            if (PayloadCodeEditor.IsExpanded)
+            {
+                JwtDecoderGrid.Children.Remove(PayloadCodeEditor);
+                ExpandedChanged?.Invoke(PayloadCodeEditor, EventArgs.Empty);
+            }
+            else
+            {
+                ExpandedChanged?.Invoke(PayloadCodeEditor, EventArgs.Empty);
+                JwtDecoderGrid.Children.Add(PayloadCodeEditor);
+            }
         }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolPage.xaml
@@ -22,25 +22,42 @@
             </TransitionCollection>
         </Grid.ChildrenTransitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
+        <Grid x:Name="MainGrid" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-        <StackPanel Spacing="0" Grid.Row="0" Margin="0,0,0,-8" >
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.SettingsTitle}" />
-            <controls:ExpandableSettingControl
+            <StackPanel Spacing="0" Grid.Row="0" Margin="0,0,0,-8" >
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.SettingsTitle}" />
+                <controls:ExpandableSettingControl
                 Title="{x:Bind ViewModel.Strings.SettingsSwitchModeLabel}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF18D;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ToggleSwitch
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF18D;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ToggleSwitch
                     Style="{StaticResource RightAlignedToggleSwitchStyle}"
                     OffContent="{x:Bind ViewModel.Strings.DecodeSwitchModeLabel}" OnContent="{x:Bind ViewModel.Strings.EncodeSwitchModeLabel}"
                     IsOn="{x:Bind ViewModel.JwtToolMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-            </controls:ExpandableSettingControl>
-        </StackPanel>
-        <jwt:JwtDecoderControl Grid.Row="1" ViewModel="{x:Bind ViewModel.DecoderViewModel, Mode=OneWay}" Visibility="{x:Bind ViewModel.JwtToolMode, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"/>
-        <jwt:JwtEncoderControl Grid.Row="1" ViewModel="{x:Bind ViewModel.EncoderViewModel, Mode=OneWay}" Visibility="{x:Bind ViewModel.JwtToolMode, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                </controls:ExpandableSettingControl>
+            </StackPanel>
+            <jwt:JwtDecoderControl
+                x:Name="JwtDecoderControl"
+                Grid.Row="1"
+                ViewModel="{x:Bind ViewModel.DecoderViewModel, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.JwtToolMode,
+                Mode=OneWay,
+                Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
+                ExpandedChanged="JwtDecoderControl_ExpandedChanged"/>
+            <jwt:JwtEncoderControl 
+                x:Name="JwtEncoderControl"
+                Grid.Row="1"
+                ViewModel="{x:Bind ViewModel.EncoderViewModel, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.JwtToolMode,
+                Mode=OneWay,
+                Converter={StaticResource BooleanToVisibilityConverter}}"
+                ExpandedChanged="JwtEncoderControl_ExpandedChanged"/>
+        </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderToolPage.xaml.cs
@@ -52,5 +52,39 @@ namespace DevToys.Views.Tools.JwtDecoderEncoder
 
             base.OnNavigatedTo(e);
         }
+
+        private void JwtDecoderControl_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (sender is UIElement uiElement)
+            {
+                if (JwtDecoderControl.IsExpanded)
+                {
+                    MainGrid.Visibility = Visibility.Collapsed;
+                    ExpandedGrid.Children.Add(uiElement);
+                }
+                else
+                {
+                    ExpandedGrid.Children.Remove(uiElement);
+                    MainGrid.Visibility = Visibility.Visible;
+                }
+            }
+        }
+
+        private void JwtEncoderControl_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (sender is UIElement uiElement)
+            {
+                if (JwtEncoderControl.IsExpanded)
+                {
+                    MainGrid.Visibility = Visibility.Collapsed;
+                    ExpandedGrid.Children.Add(uiElement);
+                }
+                else
+                {
+                    ExpandedGrid.Children.Remove(uiElement);
+                    MainGrid.Visibility = Visibility.Visible;
+                }
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtEncoderControl.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtEncoderControl.xaml
@@ -270,7 +270,9 @@
             Grid.Column="2"
             Header="{x:Bind ViewModel.LocalizedStrings.JwtPayloadLabel}"
             Text="{x:Bind ViewModel.Payload, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-            CodeLanguage="json"/>
+            CodeLanguage="json"
+            AllowExpand="True"
+            ExpandedChanged="PayloadCodeEditor_ExpandedChanged"/>
         <Grid
             x:Name="SignatureGrid"
             Grid.Row="4"

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtEncoderControl.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtEncoderControl.xaml.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using System.Composition;
 using DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder;
 using Windows.UI.Xaml;
@@ -10,11 +11,15 @@ namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
     public sealed partial class JwtEncoderControl : UserControl
     {
         public static readonly DependencyProperty ViewModelProperty
-           = DependencyProperty.Register(
-               nameof(ViewModel),
-               typeof(JwtEncoderControlViewModel),
-               typeof(JwtEncoderControl),
-               new PropertyMetadata(default(JwtEncoderControlViewModel)));
+            = DependencyProperty.Register(
+                nameof(ViewModel),
+                typeof(JwtEncoderControlViewModel),
+                typeof(JwtEncoderControl),
+                new PropertyMetadata(default(JwtEncoderControlViewModel)));
+
+        public event EventHandler? ExpandedChanged;
+
+        public bool IsExpanded { get; private set; }
 
         /// <summary>
         /// Gets the page's view model.
@@ -28,6 +33,22 @@ namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
         public JwtEncoderControl()
         {
             InitializeComponent();
+        }
+
+        private void PayloadCodeEditor_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            IsExpanded = !IsExpanded;
+            
+            if (PayloadCodeEditor.IsExpanded)
+            {
+                JwtEncoderGrid.Children.Remove(PayloadCodeEditor);
+                ExpandedChanged?.Invoke(PayloadCodeEditor, EventArgs.Empty);
+            }
+            else
+            {
+                ExpandedChanged?.Invoke(PayloadCodeEditor, EventArgs.Empty);
+                JwtEncoderGrid.Children.Add(PayloadCodeEditor);
+            }
         }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/URLEncoderDecoder/UrlEncoderDecoderToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/URLEncoderDecoder/UrlEncoderDecoderToolPage.xaml
@@ -16,42 +16,47 @@
             </TransitionCollection>
         </Grid.ChildrenTransitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+        <Grid x:Name="MainGrid" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-        <StackPanel Spacing="4" Grid.Row="0" >
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
-            <controls:ExpandableSettingControl
+            <StackPanel Spacing="4" Grid.Row="0" >
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
+                <controls:ExpandableSettingControl
+                    Grid.Row="1"
+                    Title="{x:Bind ViewModel.Strings.ConversionTitle}"
+                    Description="{x:Bind ViewModel.Strings.ConversionDescription}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF18D;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ToggleSwitch 
+                        Style="{StaticResource RightAlignedToggleSwitchStyle}"
+                        OnContent="{x:Bind ViewModel.Strings.ConversionEncode}" OffContent="{x:Bind ViewModel.Strings.ConversionDecode}"
+                        IsOn="{x:Bind ViewModel.IsEncodeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </controls:ExpandableSettingControl>
+            </StackPanel>
+
+            <controls:CustomTextBox
                 Grid.Row="1"
-                Title="{x:Bind ViewModel.Strings.ConversionTitle}"
-                Description="{x:Bind ViewModel.Strings.ConversionDescription}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF18D;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ToggleSwitch 
-                    Style="{StaticResource RightAlignedToggleSwitchStyle}"
-                    OnContent="{x:Bind ViewModel.Strings.ConversionEncode}" OffContent="{x:Bind ViewModel.Strings.ConversionDecode}"
-                    IsOn="{x:Bind ViewModel.IsEncodeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            </controls:ExpandableSettingControl>
-        </StackPanel>
+                MinHeight="150"
+                AcceptsReturn="True"
+                Header="{x:Bind ViewModel.Strings.InputTitle}"
+                Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <controls:CustomTextBox
-            Grid.Row="1"
-            MinHeight="150"
-            AcceptsReturn="True"
-            Header="{x:Bind ViewModel.Strings.InputTitle}"
-            Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <controls:CustomTextBox
-            Grid.Row="2"
-            MinHeight="150"
-            IsReadOnly="True"
-            AcceptsReturn="True"
-            Header="{x:Bind ViewModel.Strings.OutputTitle}"
-            Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"/>
-
+            <controls:CustomTextBox
+                x:Name="OutputTextBox"
+                Grid.Row="2"
+                MinHeight="150"
+                IsReadOnly="True"
+                AcceptsReturn="True"
+                Header="{x:Bind ViewModel.Strings.OutputTitle}"
+                Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
+                AllowExpand="True"
+                ExpandedChanged="OutputTextBox_ExpandedChanged"/>
+        </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/URLEncoderDecoder/UrlEncoderDecoderToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/URLEncoderDecoder/UrlEncoderDecoderToolPage.xaml.cs
@@ -52,5 +52,21 @@ namespace DevToys.Views.Tools.UrlEncoderDecoder
 
             base.OnNavigatedTo(e);
         }
+
+        private void OutputTextBox_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (OutputTextBox.IsExpanded)
+            {
+                MainGrid.Children.Remove(OutputTextBox);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputTextBox);
+            }
+            else
+            {
+                ExpandedGrid.Children.Remove(OutputTextBox);
+                MainGrid.Children.Add(OutputTextBox);
+                MainGrid.Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/JsonFormatter/JsonFormatterToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/JsonFormatter/JsonFormatterToolPage.xaml
@@ -40,103 +40,108 @@
             </TransitionCollection>
         </Grid.ChildrenTransitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-
-        <StackPanel
-            x:Name="SettingsStackPanel"
-            Grid.Row="0"
-            Spacing="4">
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
-
-            <controls:ExpandableSettingControl
-                VerticalAlignment="Stretch"
-                VerticalContentAlignment="Stretch"
-                Title="{x:Bind ViewModel.Strings.Indentation}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF6F8;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ComboBox
-                    ItemsSource="{x:Bind ViewModel.Indentations}"
-                    DisplayMemberPath="DisplayName"
-                    SelectedValue="{x:Bind ViewModel.IndentationMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                </ComboBox>
-            </controls:ExpandableSettingControl>
-            <controls:ExpandableSettingControl
-                Title="{x:Bind ViewModel.Strings.SortProperties}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF802;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ToggleSwitch 
-                    Style="{StaticResource RightAlignedToggleSwitchStyle}"
-                    IsOn="{x:Bind ViewModel.IsSortProperties, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            </controls:ExpandableSettingControl>
-        </StackPanel>
-
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition MinWidth="100"/>
-                <ColumnDefinition Width="16"/>
-                <ColumnDefinition MinWidth="100"/>
-            </Grid.ColumnDefinitions>
+        <Grid x:Name="MainGrid" RowSpacing="12">
             <Grid.RowDefinitions>
-                <RowDefinition MinHeight="100"/>
-                <RowDefinition Height="16"/>
-                <RowDefinition MinHeight="100"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <controls:CodeEditor
-                x:Name="InputCodeEditor"
-                Grid.Column="0"
+            <StackPanel
+                x:Name="SettingsStackPanel"
                 Grid.Row="0"
-                Grid.RowSpan="3"
-                Header="{x:Bind ViewModel.Strings.Input}"
-                Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                CodeLanguage="json"/>
+                Spacing="4">
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
 
-            <toolkit:GridSplitter
-                x:Name="VerticalGridSplitter"
-                Grid.Column="1"
-                Grid.Row="0"
-                Grid.RowSpan="3"
-                Width="16"
-                Margin="0,42,0,0"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Columns">
-                <toolkit:GridSplitter.Element>
-                    <FontIcon
-                        Glyph="&#xFD55;"
-                        FontSize="13"/>
-                </toolkit:GridSplitter.Element>
-            </toolkit:GridSplitter>
+                <controls:ExpandableSettingControl
+                    VerticalAlignment="Stretch"
+                    VerticalContentAlignment="Stretch"
+                    Title="{x:Bind ViewModel.Strings.Indentation}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF6F8;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ComboBox
+                        ItemsSource="{x:Bind ViewModel.Indentations}"
+                        DisplayMemberPath="DisplayName"
+                        SelectedValue="{x:Bind ViewModel.IndentationMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    </ComboBox>
+                </controls:ExpandableSettingControl>
+                <controls:ExpandableSettingControl
+                    Title="{x:Bind ViewModel.Strings.SortProperties}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF802;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ToggleSwitch 
+                        Style="{StaticResource RightAlignedToggleSwitchStyle}"
+                        IsOn="{x:Bind ViewModel.IsSortProperties, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </controls:ExpandableSettingControl>
+            </StackPanel>
 
-            <toolkit:GridSplitter
-                x:Name="HorizontalGridSplitter"
-                Grid.Row="1"
-                Grid.Column="0"
-                Grid.ColumnSpan="3"
-                Height="16"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Rows"
-                Visibility="Collapsed">
-                <toolkit:GridSplitter.Element>
-                    <FontIcon
-                        Glyph="&#xFD52;"
-                        FontSize="13"/>
-                </toolkit:GridSplitter.Element>
-            </toolkit:GridSplitter>
+            <Grid Grid.Row="1" x:Name="InputOutputGrid">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="100"/>
+                    <ColumnDefinition Width="16"/>
+                    <ColumnDefinition MinWidth="100"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition MinHeight="100"/>
+                    <RowDefinition Height="16"/>
+                    <RowDefinition MinHeight="100"/>
+                </Grid.RowDefinitions>
 
-            <controls:CodeEditor
-                x:Name="OutputCodeEditor"
-                Grid.Column="2"
-                Grid.Row="0"
-                Grid.RowSpan="3"
-                Header="{x:Bind ViewModel.Strings.Output}"
-                Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
-                CodeLanguage="json"
-                IsReadOnly="True"/>
+                <controls:CodeEditor
+                    x:Name="InputCodeEditor"
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Header="{x:Bind ViewModel.Strings.Input}"
+                    Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    CodeLanguage="json"/>
+
+                <toolkit:GridSplitter
+                    x:Name="VerticalGridSplitter"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Width="16"
+                    Margin="0,42,0,0"
+                    ResizeBehavior="BasedOnAlignment"
+                    ResizeDirection="Columns">
+                    <toolkit:GridSplitter.Element>
+                        <FontIcon
+                            Glyph="&#xFD55;"
+                            FontSize="13"/>
+                    </toolkit:GridSplitter.Element>
+                </toolkit:GridSplitter>
+
+                <toolkit:GridSplitter
+                    x:Name="HorizontalGridSplitter"
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="3"
+                    Height="16"
+                    ResizeBehavior="BasedOnAlignment"
+                    ResizeDirection="Rows"
+                    Visibility="Collapsed">
+                    <toolkit:GridSplitter.Element>
+                        <FontIcon
+                            Glyph="&#xFD52;"
+                            FontSize="13"/>
+                    </toolkit:GridSplitter.Element>
+                </toolkit:GridSplitter>
+
+                <controls:CodeEditor
+                    x:Name="OutputCodeEditor"
+                    Grid.Column="2"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Header="{x:Bind ViewModel.Strings.Output}"
+                    Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
+                    CodeLanguage="json"
+                    IsReadOnly="True"
+                    AllowExpand="True"
+                    ExpandedChanged="OutputCodeEditor_ExpandedChanged"/>
+            </Grid>
         </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/JsonFormatter/JsonFormatterToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/JsonFormatter/JsonFormatterToolPage.xaml.cs
@@ -51,5 +51,21 @@ namespace DevToys.Views.Tools.JsonFormatter
 
             base.OnNavigatedTo(e);
         }
+
+        private void OutputCodeEditor_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (OutputCodeEditor.IsExpanded)
+            {
+                InputOutputGrid.Children.Remove(OutputCodeEditor);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputCodeEditor);
+            }
+            else
+            {
+                ExpandedGrid.Children.Remove(OutputCodeEditor);
+                InputOutputGrid.Children.Add(OutputCodeEditor);
+                MainGrid.Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/SqlFormatter/SqlFormatterToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/SqlFormatter/SqlFormatterToolPage.xaml
@@ -40,108 +40,113 @@
             </TransitionCollection>
         </Grid.ChildrenTransitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-
-        <StackPanel
-            x:Name="SettingsStackPanel"
-            Grid.Row="0"
-            Spacing="4">
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
-
-            <controls:ExpandableSettingControl
-                VerticalAlignment="Stretch"
-                VerticalContentAlignment="Stretch"
-                Title="{x:Bind ViewModel.Strings.SqlLanguage}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF2EF;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ComboBox
-                    ItemsSource="{x:Bind ViewModel.SqlLanguages}"
-                    DisplayMemberPath="DisplayName"
-                    SelectedValue="{x:Bind ViewModel.SqlLanguageMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                </ComboBox>
-            </controls:ExpandableSettingControl>
-
-            <controls:ExpandableSettingControl
-                VerticalAlignment="Stretch"
-                VerticalContentAlignment="Stretch"
-                Title="{x:Bind ViewModel.Strings.Indentation}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF6F8;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ComboBox
-                    ItemsSource="{x:Bind ViewModel.Indentations}"
-                    DisplayMemberPath="DisplayName"
-                    SelectedValue="{x:Bind ViewModel.IndentationMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                </ComboBox>
-            </controls:ExpandableSettingControl>
-        </StackPanel>
-
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition MinWidth="100"/>
-                <ColumnDefinition Width="16"/>
-                <ColumnDefinition MinWidth="100"/>
-            </Grid.ColumnDefinitions>
+        <Grid x:Name="MainGrid" RowSpacing="12">
             <Grid.RowDefinitions>
-                <RowDefinition MinHeight="100"/>
-                <RowDefinition Height="16"/>
-                <RowDefinition MinHeight="100"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <controls:CodeEditor
-                x:Name="InputCodeEditor"
-                Grid.Column="0"
+            <StackPanel
+                x:Name="SettingsStackPanel"
                 Grid.Row="0"
-                Grid.RowSpan="3"
-                Header="{x:Bind ViewModel.Strings.Input}"
-                Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                CodeLanguage="sql"/>
+                Spacing="4">
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
 
-            <toolkit:GridSplitter
-                x:Name="VerticalGridSplitter"
-                Grid.Column="1"
-                Grid.Row="0"
-                Grid.RowSpan="3"
-                Width="16"
-                Margin="0,42,0,0"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Columns">
-                <toolkit:GridSplitter.Element>
-                    <FontIcon
-                        Glyph="&#xFD55;"
-                        FontSize="13"/>
-                </toolkit:GridSplitter.Element>
-            </toolkit:GridSplitter>
+                <controls:ExpandableSettingControl
+                    VerticalAlignment="Stretch"
+                    VerticalContentAlignment="Stretch"
+                    Title="{x:Bind ViewModel.Strings.SqlLanguage}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF2EF;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ComboBox
+                        ItemsSource="{x:Bind ViewModel.SqlLanguages}"
+                        DisplayMemberPath="DisplayName"
+                        SelectedValue="{x:Bind ViewModel.SqlLanguageMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    </ComboBox>
+                </controls:ExpandableSettingControl>
 
-            <toolkit:GridSplitter
-                x:Name="HorizontalGridSplitter"
-                Grid.Row="1"
-                Grid.Column="0"
-                Grid.ColumnSpan="3"
-                Height="16"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Rows"
-                Visibility="Collapsed">
-                <toolkit:GridSplitter.Element>
-                    <FontIcon
-                        Glyph="&#xFD52;"
-                        FontSize="13"/>
-                </toolkit:GridSplitter.Element>
-            </toolkit:GridSplitter>
+                <controls:ExpandableSettingControl
+                    VerticalAlignment="Stretch"
+                    VerticalContentAlignment="Stretch"
+                    Title="{x:Bind ViewModel.Strings.Indentation}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF6F8;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ComboBox
+                        ItemsSource="{x:Bind ViewModel.Indentations}"
+                        DisplayMemberPath="DisplayName"
+                        SelectedValue="{x:Bind ViewModel.IndentationMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    </ComboBox>
+                </controls:ExpandableSettingControl>
+            </StackPanel>
 
-            <controls:CodeEditor
-                x:Name="OutputCodeEditor"
-                Grid.Column="2"
-                Grid.Row="0"
-                Grid.RowSpan="3"
-                Header="{x:Bind ViewModel.Strings.Output}"
-                Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
-                CodeLanguage="sql"
-                IsReadOnly="True"/>
+            <Grid Grid.Row="1" x:Name="InputOutputGrid">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="100"/>
+                    <ColumnDefinition Width="16"/>
+                    <ColumnDefinition MinWidth="100"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition MinHeight="100"/>
+                    <RowDefinition Height="16"/>
+                    <RowDefinition MinHeight="100"/>
+                </Grid.RowDefinitions>
+
+                <controls:CodeEditor
+                    x:Name="InputCodeEditor"
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Header="{x:Bind ViewModel.Strings.Input}"
+                    Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    CodeLanguage="sql"/>
+
+                <toolkit:GridSplitter
+                    x:Name="VerticalGridSplitter"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Width="16"
+                    Margin="0,42,0,0"
+                    ResizeBehavior="BasedOnAlignment"
+                    ResizeDirection="Columns">
+                    <toolkit:GridSplitter.Element>
+                        <FontIcon
+                            Glyph="&#xFD55;"
+                            FontSize="13"/>
+                    </toolkit:GridSplitter.Element>
+                </toolkit:GridSplitter>
+
+                <toolkit:GridSplitter
+                    x:Name="HorizontalGridSplitter"
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="3"
+                    Height="16"
+                    ResizeBehavior="BasedOnAlignment"
+                    ResizeDirection="Rows"
+                    Visibility="Collapsed">
+                    <toolkit:GridSplitter.Element>
+                        <FontIcon
+                            Glyph="&#xFD52;"
+                            FontSize="13"/>
+                    </toolkit:GridSplitter.Element>
+                </toolkit:GridSplitter>
+
+                <controls:CodeEditor
+                    x:Name="OutputCodeEditor"
+                    Grid.Column="2"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Header="{x:Bind ViewModel.Strings.Output}"
+                    Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
+                    CodeLanguage="sql"
+                    IsReadOnly="True"
+                    AllowExpand="True"
+                    ExpandedChanged="OutputCodeEditor_ExpandedChanged"/>
+            </Grid>
         </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/SqlFormatter/SqlFormatterToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/SqlFormatter/SqlFormatterToolPage.xaml.cs
@@ -51,5 +51,21 @@ namespace DevToys.Views.Tools.SqlFormatter
 
             base.OnNavigatedTo(e);
         }
+
+        private void OutputCodeEditor_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (OutputCodeEditor.IsExpanded)
+            {
+                InputOutputGrid.Children.Remove(OutputCodeEditor);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputCodeEditor);
+            }
+            else
+            {
+                ExpandedGrid.Children.Remove(OutputCodeEditor);
+                InputOutputGrid.Children.Add(OutputCodeEditor);
+                MainGrid.Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/XmlFormatter/XmlFormatterToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/XmlFormatter/XmlFormatterToolPage.xaml
@@ -40,106 +40,111 @@
             </TransitionCollection>
         </Grid.ChildrenTransitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-
-        <StackPanel
-            x:Name="SettingsStackPanel"
-            Grid.Row="0"
-            Spacing="4">
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
-
-            <controls:ExpandableSettingControl
-                VerticalAlignment="Stretch"
-                VerticalContentAlignment="Stretch"
-                Title="{x:Bind ViewModel.Strings.Indentation}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF6F8;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ComboBox
-                    ItemsSource="{x:Bind ViewModel.Indentations}"
-                    DisplayMemberPath="DisplayName"
-                    SelectedValue="{x:Bind ViewModel.IndentationMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                </ComboBox>
-            </controls:ExpandableSettingControl>
- 
-            <controls:ExpandableSettingControl
-                VerticalAlignment="Stretch"
-                VerticalContentAlignment="Stretch"
-                Title="{x:Bind ViewModel.Strings.NewLineOnAttributesName}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xf7ed;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ToggleSwitch 
-                    Style="{StaticResource RightAlignedToggleSwitchStyle}" 
-                    IsOn="{x:Bind ViewModel.IsNewLineOnAttributes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            </controls:ExpandableSettingControl>
-        </StackPanel>
-
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition MinWidth="100"/>
-                <ColumnDefinition Width="16"/>
-                <ColumnDefinition MinWidth="100"/>
-            </Grid.ColumnDefinitions>
+        <Grid x:Name="MainGrid" RowSpacing="12">
             <Grid.RowDefinitions>
-                <RowDefinition MinHeight="100"/>
-                <RowDefinition Height="16"/>
-                <RowDefinition MinHeight="100"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <controls:CodeEditor
-                x:Name="InputCodeEditor"
-                Grid.Column="0"
+            <StackPanel
+                x:Name="SettingsStackPanel"
                 Grid.Row="0"
-                Grid.RowSpan="3"
-                Header="{x:Bind ViewModel.Strings.Input}"
-                Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                CodeLanguage="xml"/>
+                Spacing="4">
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
 
-            <toolkit:GridSplitter
-                x:Name="VerticalGridSplitter"
-                Grid.Column="1"
-                Grid.Row="0"
-                Grid.RowSpan="3"
-                Width="16"
-                Margin="0,42,0,0"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Columns">
-                <toolkit:GridSplitter.Element>
-                    <FontIcon
-                        Glyph="&#xFD55;"
-                        FontSize="13"/>
-                </toolkit:GridSplitter.Element>
-            </toolkit:GridSplitter>
+                <controls:ExpandableSettingControl
+                    VerticalAlignment="Stretch"
+                    VerticalContentAlignment="Stretch"
+                    Title="{x:Bind ViewModel.Strings.Indentation}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF6F8;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ComboBox
+                        ItemsSource="{x:Bind ViewModel.Indentations}"
+                        DisplayMemberPath="DisplayName"
+                        SelectedValue="{x:Bind ViewModel.IndentationMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    </ComboBox>
+                </controls:ExpandableSettingControl>
 
-            <toolkit:GridSplitter
-                x:Name="HorizontalGridSplitter"
-                Grid.Row="1"
-                Grid.Column="0"
-                Grid.ColumnSpan="3"
-                Height="16"
-                ResizeBehavior="BasedOnAlignment"
-                ResizeDirection="Rows"
-                Visibility="Collapsed">
-                    <toolkit:GridSplitter.Element>
-                        <FontIcon
-                        Glyph="&#xFD52;"
-                        FontSize="13"/>
-                    </toolkit:GridSplitter.Element>
-            </toolkit:GridSplitter>
+                <controls:ExpandableSettingControl
+                    VerticalAlignment="Stretch"
+                    VerticalContentAlignment="Stretch"
+                    Title="{x:Bind ViewModel.Strings.NewLineOnAttributesName}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xf7ed;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ToggleSwitch 
+                        Style="{StaticResource RightAlignedToggleSwitchStyle}" 
+                        IsOn="{x:Bind ViewModel.IsNewLineOnAttributes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </controls:ExpandableSettingControl>
+            </StackPanel>
 
-            <controls:CodeEditor
-                x:Name="OutputCodeEditor"
-                Grid.Column="2"
-                Grid.Row="0"
-                Grid.RowSpan="3"
-                Header="{x:Bind ViewModel.Strings.Output}"
-                Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
-                CodeLanguage="xml"
-                IsReadOnly="True"/>
+            <Grid Grid.Row="1" x:Name="InputOutputGrid">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="100"/>
+                    <ColumnDefinition Width="16"/>
+                    <ColumnDefinition MinWidth="100"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition MinHeight="100"/>
+                    <RowDefinition Height="16"/>
+                    <RowDefinition MinHeight="100"/>
+                </Grid.RowDefinitions>
+
+                <controls:CodeEditor
+                    x:Name="InputCodeEditor"
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Header="{x:Bind ViewModel.Strings.Input}"
+                    Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    CodeLanguage="xml"/>
+
+                <toolkit:GridSplitter
+                    x:Name="VerticalGridSplitter"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Width="16"
+                    Margin="0,42,0,0"
+                    ResizeBehavior="BasedOnAlignment"
+                    ResizeDirection="Columns">
+                        <toolkit:GridSplitter.Element>
+                            <FontIcon
+                            Glyph="&#xFD55;"
+                            FontSize="13"/>
+                        </toolkit:GridSplitter.Element>
+                </toolkit:GridSplitter>
+
+                <toolkit:GridSplitter
+                    x:Name="HorizontalGridSplitter"
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="3"
+                    Height="16"
+                    ResizeBehavior="BasedOnAlignment"
+                    ResizeDirection="Rows"
+                    Visibility="Collapsed">
+                        <toolkit:GridSplitter.Element>
+                            <FontIcon
+                            Glyph="&#xFD52;"
+                            FontSize="13"/>
+                        </toolkit:GridSplitter.Element>
+                </toolkit:GridSplitter>
+
+                <controls:CodeEditor
+                    x:Name="OutputCodeEditor"
+                    Grid.Column="2"
+                    Grid.Row="0"
+                    Grid.RowSpan="3"
+                    Header="{x:Bind ViewModel.Strings.Output}"
+                    Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
+                    CodeLanguage="xml"
+                    IsReadOnly="True"
+                    AllowExpand="True"
+                    ExpandedChanged="OutputCodeEditor_ExpandedChanged"/>
+            </Grid>
         </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Formatters/XmlFormatter/XmlFormatterToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Formatters/XmlFormatter/XmlFormatterToolPage.xaml.cs
@@ -51,5 +51,21 @@ namespace DevToys.Views.Tools.XmlFormatter
 
             base.OnNavigatedTo(e);
         }
+
+        private void OutputCodeEditor_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (OutputCodeEditor.IsExpanded)
+            {
+                InputOutputGrid.Children.Remove(OutputCodeEditor);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputCodeEditor);
+            }
+            else
+            {
+                ExpandedGrid.Children.Remove(OutputCodeEditor);
+                InputOutputGrid.Children.Add(OutputCodeEditor);
+                MainGrid.Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/Text/StringEscapeUnescape/StringEscapeUnescapeToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/StringEscapeUnescape/StringEscapeUnescapeToolPage.xaml
@@ -15,42 +15,47 @@
             </TransitionCollection>
         </Grid.ChildrenTransitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+        <Grid x:Name="MainGrid" RowSpacing="12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-        <StackPanel Spacing="4" Grid.Row="0" >
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
-            <controls:ExpandableSettingControl
+            <StackPanel Spacing="4" Grid.Row="0" >
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
+                <controls:ExpandableSettingControl
+                    Grid.Row="1"
+                    Title="{x:Bind ViewModel.Strings.ConversionTitle}"
+                    Description="{x:Bind ViewModel.Strings.ConversionDescription}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF18D;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ToggleSwitch 
+                        Style="{StaticResource RightAlignedToggleSwitchStyle}"
+                        OnContent="{x:Bind ViewModel.Strings.ConversionEncode}" OffContent="{x:Bind ViewModel.Strings.ConversionDecode}"
+                        IsOn="{x:Bind ViewModel.IsEscapeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </controls:ExpandableSettingControl>
+            </StackPanel>
+
+            <controls:CustomTextBox
                 Grid.Row="1"
-                Title="{x:Bind ViewModel.Strings.ConversionTitle}"
-                Description="{x:Bind ViewModel.Strings.ConversionDescription}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xF18D;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ToggleSwitch 
-                    Style="{StaticResource RightAlignedToggleSwitchStyle}"
-                    OnContent="{x:Bind ViewModel.Strings.ConversionEncode}" OffContent="{x:Bind ViewModel.Strings.ConversionDecode}"
-                    IsOn="{x:Bind ViewModel.IsEscapeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            </controls:ExpandableSettingControl>
-        </StackPanel>
+                MinHeight="150"
+                AcceptsReturn="True"
+                Header="{x:Bind ViewModel.Strings.InputTitle}"
+                Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <controls:CustomTextBox
-            Grid.Row="1"
-            MinHeight="150"
-            AcceptsReturn="True"
-            Header="{x:Bind ViewModel.Strings.InputTitle}"
-            Text="{x:Bind ViewModel.InputValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <controls:CustomTextBox
-            Grid.Row="2"
-            MinHeight="150"
-            IsReadOnly="True"
-            AcceptsReturn="True"
-            Header="{x:Bind ViewModel.Strings.OutputTitle}"
-            Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"/>
-
+            <controls:CustomTextBox
+                x:Name="OutputTextBox"
+                Grid.Row="2"
+                MinHeight="150"
+                IsReadOnly="True"
+                AcceptsReturn="True"
+                Header="{x:Bind ViewModel.Strings.OutputTitle}"
+                Text="{x:Bind ViewModel.OutputValue, Mode=OneWay}"
+                AllowExpand="True"
+                ExpandedChanged="CustomTextBox_ExpandedChanged"/>
+        </Grid>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Text/StringEscapeUnescape/StringEscapeUnescapeToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Text/StringEscapeUnescape/StringEscapeUnescapeToolPage.xaml.cs
@@ -58,5 +58,21 @@ namespace DevToys.Views.Tools.StringEscapeUnescape
 
             base.OnNavigatedTo(e);
         }
+
+        private void CustomTextBox_ExpandedChanged(object sender, System.EventArgs e)
+        {
+            if (OutputTextBox.IsExpanded)
+            {
+                MainGrid.Children.Remove(OutputTextBox);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputTextBox);
+            }
+            else
+            {
+                ExpandedGrid.Children.Remove(OutputTextBox);
+                MainGrid.Children.Add(OutputTextBox);
+                MainGrid.Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml
@@ -34,7 +34,8 @@
                 <EntranceThemeTransition IsStaggeringEnabled="True" FromVerticalOffset="50"/>
             </TransitionCollection>
         </Grid.ChildrenTransitions>
-        <Grid x:Name="MainControl">
+
+        <Grid x:Name="MainGrid">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition x:Name="InputGridRow" MinHeight="200"/>
@@ -113,13 +114,13 @@
             Grid.Row="3"
             Header="{x:Bind ViewModel.Strings.Difference}"
             IsReadOnly="True"
-            AllowExpand="True"
-            ExpandedChanged="OutputTextEditor_ExpandedChanged"
             IsDiffViewMode="True"
             InlineDiffViewMode="{x:Bind ViewModel.InlineMode, Mode=OneWay}"
             DiffLeftText="{x:Bind ViewModel.OldText, Mode=OneWay}"
-            DiffRightText="{x:Bind ViewModel.NewText, Mode=OneWay}"/>
+            DiffRightText="{x:Bind ViewModel.NewText, Mode=OneWay}"
+            AllowExpand="True"
+            ExpandedChanged="OutputTextEditor_ExpandedChanged"/>
         </Grid>
-        <Grid x:Name="ExpandedControl"/>
+        <Grid x:Name="ExpandedGrid"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml
@@ -34,88 +34,92 @@
                 <EntranceThemeTransition IsStaggeringEnabled="True" FromVerticalOffset="50"/>
             </TransitionCollection>
         </Grid.ChildrenTransitions>
+        <Grid x:Name="MainControl">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition x:Name="InputGridRow" MinHeight="200"/>
+                <RowDefinition x:Name="HorizontalGridSplitterRow" Height="16"/>
+                <RowDefinition MinHeight="200"/>
+            </Grid.RowDefinitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition x:Name="InputGridRow" MinHeight="200"/>
-            <RowDefinition x:Name="HorizontalGridSplitterRow" Height="16"/>
-            <RowDefinition MinHeight="200"/>
-        </Grid.RowDefinitions>
+            <StackPanel Grid.Row="0" Spacing="4" Margin="0,0,0,12">
+                <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
 
-        <StackPanel Grid.Row="0" Spacing="4" Margin="0,0,0,12">
-            <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.Configuration}" />
-
-            <controls:ExpandableSettingControl
+                <controls:ExpandableSettingControl
                 VerticalAlignment="Stretch"
                 VerticalContentAlignment="Stretch"
                 Title="{x:Bind ViewModel.Strings.InlineDifference}">
-                <controls:ExpandableSettingControl.Icon>
-                    <FontIcon Glyph="&#xFD5E;" />
-                </controls:ExpandableSettingControl.Icon>
-                <ToggleSwitch
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xFD5E;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ToggleSwitch
                     Style="{StaticResource RightAlignedToggleSwitchStyle}"
                     IsOn="{x:Bind ViewModel.InlineMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-            </controls:ExpandableSettingControl>
-        </StackPanel>
+                </controls:ExpandableSettingControl>
+            </StackPanel>
 
-        <Grid x:Name="InputGrid" Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition MinWidth="150"/>
-                <ColumnDefinition Width="16"/>
-                <ColumnDefinition MinWidth="150"/>
-            </Grid.ColumnDefinitions>
+            <Grid x:Name="InputGrid" Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="150"/>
+                    <ColumnDefinition Width="16"/>
+                    <ColumnDefinition MinWidth="150"/>
+                </Grid.ColumnDefinitions>
 
-            <controls:CodeEditor
+                <controls:CodeEditor
                 x:Name="LeftTextEditor"
                 Grid.Column="0"
                 MinHeight="200"
                 Header="{x:Bind ViewModel.Strings.LeftText}"
                 Text="{x:Bind ViewModel.OldText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
-            <toolkit:GridSplitter
+                <toolkit:GridSplitter
                 x:Name="InputGridSplitter"
                 Grid.Column="1"
                 Width="16"
                 Margin="0,42,0,0"
                 ResizeBehavior="BasedOnAlignment"
                 ResizeDirection="Auto">
-                <toolkit:GridSplitter.Element>
-                    <FontIcon
+                    <toolkit:GridSplitter.Element>
+                        <FontIcon
                         Glyph="&#xFD55;"
                         FontSize="13"/>
-                </toolkit:GridSplitter.Element>
-            </toolkit:GridSplitter>
+                    </toolkit:GridSplitter.Element>
+                </toolkit:GridSplitter>
 
-            <controls:CodeEditor
+                <controls:CodeEditor
                 x:Name="RightTextEditor"
                 Grid.Column="2"
                 MinHeight="200"
                 Header="{x:Bind ViewModel.Strings.RightText}"
                 Text="{x:Bind ViewModel.NewText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-        </Grid>
+            </Grid>
 
-        <toolkit:GridSplitter
+            <toolkit:GridSplitter
             x:Name="OutputGridSplitter"
             Grid.Row="2"
             Height="16"
             ResizeBehavior="BasedOnAlignment"
             ResizeDirection="Auto">
-            <toolkit:GridSplitter.Element>
-                <FontIcon
+                <toolkit:GridSplitter.Element>
+                    <FontIcon
                     Glyph="&#xFD52;"
                     FontSize="13"/>
-            </toolkit:GridSplitter.Element>
-        </toolkit:GridSplitter>
+                </toolkit:GridSplitter.Element>
+            </toolkit:GridSplitter>
 
-        <controls:CodeEditor
-            x:Name="OuputTextEditor"
+            <controls:CodeEditor
+            x:Name="OutputTextEditor"
             MinHeight="200"
             Grid.Row="3"
             Header="{x:Bind ViewModel.Strings.Difference}"
             IsReadOnly="True"
+            AllowExpand="True"
+            ExpandedChanged="OutputTextEditor_ExpandedChanged"
             IsDiffViewMode="True"
             InlineDiffViewMode="{x:Bind ViewModel.InlineMode, Mode=OneWay}"
             DiffLeftText="{x:Bind ViewModel.OldText, Mode=OneWay}"
             DiffRightText="{x:Bind ViewModel.NewText, Mode=OneWay}"/>
+        </Grid>
+        <Grid x:Name="ExpandedControl"/>
     </Grid>
 </Page>

--- a/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using DevToys.Api.Core.Navigation;
 using DevToys.Shared.Core;
 using DevToys.ViewModels.Tools.TextDiff;
@@ -45,6 +46,22 @@ namespace DevToys.Views.Tools.TextDiff
             }
 
             base.OnNavigatedTo(e);
+        }
+
+        private void OutputTextEditor_ExpandedChanged(object sender, EventArgs e)
+        {
+            if (OutputTextEditor.IsExpanded)
+            {
+                MainControl.Children.Remove(OutputTextEditor);
+                MainControl.Visibility = Visibility.Collapsed;
+                ExpandedControl.Children.Add(OutputTextEditor);
+            }
+            else
+            {
+                ExpandedControl.Children.Remove(OutputTextEditor);
+                MainControl.Children.Add(OutputTextEditor);
+                MainControl.Visibility = Visibility.Visible;
+            }
         }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/Text/TextDiff/TextDiffToolPage.xaml.cs
@@ -52,15 +52,15 @@ namespace DevToys.Views.Tools.TextDiff
         {
             if (OutputTextEditor.IsExpanded)
             {
-                MainControl.Children.Remove(OutputTextEditor);
-                MainControl.Visibility = Visibility.Collapsed;
-                ExpandedControl.Children.Add(OutputTextEditor);
+                MainGrid.Children.Remove(OutputTextEditor);
+                MainGrid.Visibility = Visibility.Collapsed;
+                ExpandedGrid.Children.Add(OutputTextEditor);
             }
             else
             {
-                ExpandedControl.Children.Remove(OutputTextEditor);
-                MainControl.Children.Add(OutputTextEditor);
-                MainControl.Visibility = Visibility.Visible;
+                ExpandedGrid.Children.Remove(OutputTextEditor);
+                MainGrid.Children.Add(OutputTextEditor);
+                MainGrid.Visibility = Visibility.Visible;
             }
         }
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature or enhancement
- [x] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

I have a small change to propose. I thought it would be nice to create a mechanism whereby various code editors could be "expanded". In particular, I was finding that the diff editor is very small, and I am often comparing large files.

I have added a DependencyProperty to the code editor allowing it to display an expand/collapse button. Pressing the button triggers an event that the parent control can handle. From there, the UI can be adjusted such that the editor is larger than normal.

Once the mechanism is in place, other tool pages can support expandable code editors using the same mechanism, following these steps.
 - In XAML
   - Set `AllowExpand="True"` on the `CodeEditor` and subscribe to `ExpandedChanged`.
   - Create a placeholder control into which the `CodeEditor` can be placed to fill the whole page.
 - In code-behind
   - When the `CodeEditor` is expanded, move it into the placeholder control. Optionally hide other controls.
   - When the `CodeEditor` is collapsed, move it back to its original control. Optionally show other controls.
 
I know this is not really nice MVVM, but (a) `CodeEditor` doesn't have a ViewModel anyway and (b) since this is purely UI manipulation, I don't mind doing it in the code-behind. If this is not good architecture (or if you don't like this feature), of course there is no obligation to accept! 😊

**NOTE:** It is recommended to review this PR with "Hide whitespace" selected so that the changes in `TextDiffToolPage.xaml` do not look as big.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

https://github.com/veler/DevToys/assets/7417301/71f31fd4-83d5-4a79-bc49-a53828faef6c

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)