### PR TITLE
[Dev/2.0] close context menu on window events

### DIFF
--- a/src/app/dev/DevToys.Blazor/Components/ContextMenu/ContextMenu.razor.cs
+++ b/src/app/dev/DevToys.Blazor/Components/ContextMenu/ContextMenu.razor.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Components.Web;
 
 namespace DevToys.Blazor.Components;
 
-// TODO: Close the context menu when the window lose focus or get resized.
 public partial class ContextMenu : StyledComponentBase
 {
     private bool _isOpen;

--- a/src/app/dev/DevToys.Blazor/Core/Services/ContextMenuService.cs
+++ b/src/app/dev/DevToys.Blazor/Core/Services/ContextMenuService.cs
@@ -3,6 +3,18 @@
 public sealed class ContextMenuService
 {
     private readonly object _lock = new();
+    private readonly IWindowService _windowService;
+
+    public ContextMenuService(IWindowService windowService)
+    {
+        Guard.IsNotNull(windowService);
+        _windowService = windowService;
+
+        _windowService.WindowLostFocus += WindowService_MajorWindowChange;
+        _windowService.WindowClosing += WindowService_MajorWindowChange;
+        _windowService.WindowLocationChanged += WindowService_MajorWindowChange;
+        _windowService.WindowSizeChanged += WindowService_MajorWindowChange;
+    }
 
     internal bool IsContextMenuOpened { get; private set; }
 
@@ -38,5 +50,10 @@ public sealed class ContextMenuService
     internal void OnCloseContextMenuRequested()
     {
         CloseContextMenuRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void WindowService_MajorWindowChange(object? sender, EventArgs e)
+    {
+        OnCloseContextMenuRequested();
     }
 }

--- a/src/app/dev/DevToys.Blazor/Core/Services/IWindowService.cs
+++ b/src/app/dev/DevToys.Blazor/Core/Services/IWindowService.cs
@@ -1,0 +1,12 @@
+﻿namespace DevToys.Blazor.Core.Services;
+
+public interface IWindowService
+{
+    event EventHandler<EventArgs>? WindowLostFocus;
+
+    event EventHandler<EventArgs>? WindowLocationChanged;
+
+    event EventHandler<EventArgs>? WindowSizeChanged;
+
+    event EventHandler<EventArgs>? WindowClosing;
+}

--- a/src/app/dev/platforms/desktop/DevToys.MacOS/App.xaml.cs
+++ b/src/app/dev/platforms/desktop/DevToys.MacOS/App.xaml.cs
@@ -8,4 +8,13 @@ public partial class App : Application
 
         MainPage = new MainPage();
     }
+
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        Window window = base.CreateWindow(activationState);
+        window.Width = 800;
+        window.Height = 600;
+
+        return window;
+    }
 }

--- a/src/app/dev/platforms/desktop/DevToys.MacOS/Core/WindowService.cs
+++ b/src/app/dev/platforms/desktop/DevToys.MacOS/Core/WindowService.cs
@@ -1,0 +1,40 @@
+using DevToys.Blazor.Core.Services;
+using Foundation;
+
+namespace DevToys.MacOS.Core;
+
+internal sealed class WindowService : IWindowService
+{
+    public event EventHandler<EventArgs>? WindowLostFocus;
+    public event EventHandler<EventArgs>? WindowLocationChanged;
+    public event EventHandler<EventArgs>? WindowSizeChanged;
+    public event EventHandler<EventArgs>? WindowClosing;
+
+    public WindowService()
+    {
+        NSNotificationCenter.DefaultCenter.AddObserver(new NSString("NSWindowDidResignMainNotification"), OnWindowLostFocus);
+        NSNotificationCenter.DefaultCenter.AddObserver(new NSString("NSWindowWillMoveNotification"), OnWindowLocationChanged);
+        NSNotificationCenter.DefaultCenter.AddObserver(new NSString("NSWindowWillStartLiveResizeNotification"), OnWindowSizeChanged);
+        NSNotificationCenter.DefaultCenter.AddObserver(new NSString("NSWindowWillCloseNotification"), OnWindowClosing);
+    }
+
+    public void OnWindowLostFocus(NSNotification notification)
+    {
+        WindowLostFocus?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void OnWindowLocationChanged(NSNotification notification)
+    {
+        WindowLocationChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void OnWindowSizeChanged(NSNotification notification)
+    {
+        WindowSizeChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void OnWindowClosing(NSNotification notification)
+    {
+        WindowClosing?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/app/dev/platforms/desktop/DevToys.MacOS/MauiProgram.cs
+++ b/src/app/dev/platforms/desktop/DevToys.MacOS/MauiProgram.cs
@@ -97,8 +97,8 @@ public partial class MauiProgram
         });
 
         serviceCollection.AddSingleton(provider => MefComposer!.Provider);
-        serviceCollection.TryAddScoped<PopoverService, PopoverService>();
-        serviceCollection.TryAddScoped<ContextMenuService, ContextMenuService>();
+        serviceCollection.AddScoped<PopoverService, PopoverService>();
+        serviceCollection.AddScoped<ContextMenuService, ContextMenuService>();
 
         ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
 

--- a/src/app/dev/platforms/desktop/DevToys.MacOS/MauiProgram.cs
+++ b/src/app/dev/platforms/desktop/DevToys.MacOS/MauiProgram.cs
@@ -1,11 +1,10 @@
 ﻿using DevToys.Api;
 using DevToys.Blazor.Core.Languages;
-using DevToys.Blazor.Services;
+using DevToys.Blazor.Core.Services;
 using DevToys.Business.ViewModels;
 using DevToys.Core.Logging;
 using DevToys.Core.Mef;
 using DevToys.MacOS.Core;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
 using PredefinedSettings = DevToys.Core.Settings.PredefinedSettings;
@@ -97,6 +96,7 @@ public partial class MauiProgram
         });
 
         serviceCollection.AddSingleton(provider => MefComposer!.Provider);
+        serviceCollection.AddSingleton<IWindowService, WindowService>();
         serviceCollection.AddScoped<PopoverService, PopoverService>();
         serviceCollection.AddScoped<ContextMenuService, ContextMenuService>();
 

--- a/src/app/dev/platforms/desktop/DevToys.Windows/Core/WindowService.cs
+++ b/src/app/dev/platforms/desktop/DevToys.Windows/Core/WindowService.cs
@@ -1,0 +1,46 @@
+﻿using System.Windows;
+using DevToys.Blazor.Core.Services;
+
+namespace DevToys.Windows.Core;
+
+internal sealed class WindowService : IWindowService
+{
+    private Window? _window;
+
+    public event EventHandler<EventArgs>? WindowLostFocus;
+    public event EventHandler<EventArgs>? WindowLocationChanged;
+    public event EventHandler<EventArgs>? WindowSizeChanged;
+    public event EventHandler<EventArgs>? WindowClosing;
+
+    internal void SetWindow(Window window)
+    {
+        Guard.IsNull(_window);
+        Guard.IsNotNull(window);
+        _window = window;
+
+        _window.LostFocus += Window_LostFocus;
+        _window.LocationChanged += Window_LocationChanged;
+        _window.SizeChanged += Window_SizeChanged;
+        _window.Closing += Window_Closing;
+    }
+
+    private void Window_LostFocus(object sender, RoutedEventArgs e)
+    {
+        WindowLostFocus?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Window_LocationChanged(object? sender, EventArgs e)
+    {
+        WindowLocationChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        WindowSizeChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Window_Closing(object? sender, CancelEventArgs e)
+    {
+        WindowClosing?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/app/dev/platforms/desktop/DevToys.Windows/MainWindow.xaml
+++ b/src/app/dev/platforms/desktop/DevToys.Windows/MainWindow.xaml
@@ -8,6 +8,7 @@
     xmlns:controls="clr-namespace:DevToys.Windows.Controls"
     xmlns:blazor="clr-namespace:Microsoft.AspNetCore.Components.WebView.Wpf;assembly=Microsoft.AspNetCore.Components.WebView.Wpf"
     mc:Ignorable="d"
+    Loaded="MainWindow_Loaded"
     Title="MainWindow"
     Height="450"
     Width="800"

--- a/src/app/dev/platforms/desktop/DevToys.Windows/MainWindow.xaml.cs
+++ b/src/app/dev/platforms/desktop/DevToys.Windows/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using DevToys.Api;
+﻿using System;
+using DevToys.Api;
 using DevToys.Blazor.Core.Languages;
 using DevToys.Blazor.Core.Services;
 using DevToys.Business.ViewModels;
@@ -9,7 +10,6 @@ using DevToys.Windows.Controls;
 using DevToys.Windows.Core;
 using Microsoft.AspNetCore.Components.WebView;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using PredefinedSettings = DevToys.Core.Settings.PredefinedSettings;
 
@@ -23,6 +23,7 @@ public partial class MainWindow : MicaWindowWithOverlay
     private static MainWindow? mainWindowInstance;
 
     private readonly MefComposer _mefComposer;
+    private readonly ServiceProvider _serviceProvider;
     private readonly DateTime _uiLoadingTime;
     private ILogger? _logger;
 
@@ -33,7 +34,7 @@ public partial class MainWindow : MicaWindowWithOverlay
         DateTime startTime = DateTime.Now;
 
         // Initialize services and logging.
-        ServiceProvider serviceProvider = InitializeServices();
+        _serviceProvider = InitializeServices();
 
         // Listen for unhandled exceptions.
         AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
@@ -58,7 +59,7 @@ public partial class MainWindow : MicaWindowWithOverlay
         LanguageManager.Instance.SetCurrentCulture(languageDefinition);
 
         // Load the UI.
-        Resources.Add("services", serviceProvider);
+        Resources.Add("services", _serviceProvider);
         InitializeComponent();
 
         _themeListener = _mefComposer.Provider.Import<IThemeListener>();
@@ -66,6 +67,12 @@ public partial class MainWindow : MicaWindowWithOverlay
 
         blazorWebView.BlazorWebViewInitializing += BlazorWebView_BlazorWebViewInitializing;
         blazorWebView.BlazorWebViewInitialized += BlazorWebView_BlazorWebViewInitialized;
+    }
+
+    private void MainWindow_Loaded(object sender, System.Windows.RoutedEventArgs e)
+    {
+        var windowService = (WindowService)_serviceProvider.GetService<IWindowService>()!;
+        windowService.SetWindow(this);
     }
 
     private void BlazorWebView_BlazorWebViewInitializing(object? sender, BlazorWebViewInitializingEventArgs e)
@@ -113,8 +120,9 @@ public partial class MainWindow : MicaWindowWithOverlay
         });
 
         serviceCollection.AddSingleton(provider => _mefComposer.Provider);
-        serviceCollection.TryAddScoped<PopoverService, PopoverService>();
-        serviceCollection.TryAddScoped<ContextMenuService, ContextMenuService>();
+        serviceCollection.AddSingleton<IWindowService, WindowService>();
+        serviceCollection.AddScoped<PopoverService, PopoverService>();
+        serviceCollection.AddScoped<ContextMenuService, ContextMenuService>();
 
         ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

We added context menu support. However, the context menu would not close when :
- The window is resized.
- The window is moved.
- The window loses focus.
- The window is about to get closed.

## What is the new behavior?

We now close the context menu on all these events, on Windows and MacOS.

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [X] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [X] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)