### PR TITLE
Allow token validation without signature

### DIFF
--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -1763,6 +1763,11 @@ namespace DevToys
         public string SignatureLabel => _resources.GetString("SignatureLabel");
 
         /// <summary>
+        /// Gets the resource JwtNotValidated.
+        /// </summary>
+        public string JwtNotValidated => _resources.GetString("JwtNotValidated");
+
+        /// <summary>
         /// Gets the resource JwtIsValidMessage.
         /// </summary>
         public string JwtIsValidMessage => _resources.GetString("JwtIsValidMessage");
@@ -1786,6 +1791,11 @@ namespace DevToys
         /// Gets the resource DecodeValidateAudienceLabel.
         /// </summary>
         public string DecodeValidateAudienceLabel => _resources.GetString("DecodeValidateAudienceLabel");
+
+        /// <summary>
+        /// Gets the resource DecodeValidateIssuerSigningKey.
+        /// </summary>
+        public string DecodeValidateIssuerSigningKey => _resources.GetString("DecodeValidateIssuerSigningKey");
 
         /// <summary>
         /// Gets the resource DecodeValidateIssuerLabel.

--- a/src/dev/impl/DevToys/Models/JwtDecoderEncoder/DecoderParameters.cs
+++ b/src/dev/impl/DevToys/Models/JwtDecoderEncoder/DecoderParameters.cs
@@ -8,6 +8,8 @@ namespace DevToys.Models.JwtDecoderEncoder
     {
         public bool ValidateSignature { get; set; }
 
+        public bool ValidateIssuerSigningKey { get; set; }
+
         public bool ValidateActor { get; set; }
 
         public bool ValidateLifetime { get; set; }

--- a/src/dev/impl/DevToys/Strings/en-US/JwtDecoderEncoder.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/JwtDecoderEncoder.resw
@@ -195,8 +195,11 @@
   <data name="SignatureLabel" xml:space="preserve">
     <value>Signature</value>
   </data>
+  <data name="JwtNotValidated" xml:space="preserve">
+  <value>Token not validated (no parameters selected)</value>
+</data>
   <data name="JwtIsValidMessage" xml:space="preserve">
-    <value>Signature Verified</value>
+    <value>Token Validated</value>
   </data>
   <data name="InvalidPublicKeyError" xml:space="preserve">
     <value>Invalid Public Key</value>
@@ -210,6 +213,9 @@
   <data name="DecodeValidateAudienceLabel" xml:space="preserve">
     <value>Validate audience</value>
   </data>
+  <data name="DecodeValidateIssuerSigningKey" xml:space="preserve">
+  <value>Validate issuer signing key</value>
+</data>
   <data name="DecodeValidateIssuerLabel" xml:space="preserve">
     <value>Validate issuer</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/en-US/JwtDecoderEncoder.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/JwtDecoderEncoder.resw
@@ -196,8 +196,8 @@
     <value>Signature</value>
   </data>
   <data name="JwtNotValidated" xml:space="preserve">
-  <value>Token not validated (no parameters selected)</value>
-</data>
+    <value>Token not validated (no parameters selected)</value>
+  </data>
   <data name="JwtIsValidMessage" xml:space="preserve">
     <value>Token Validated</value>
   </data>
@@ -214,8 +214,8 @@
     <value>Validate audience</value>
   </data>
   <data name="DecodeValidateIssuerSigningKey" xml:space="preserve">
-  <value>Validate issuer signing key</value>
-</data>
+    <value>Validate issuer signing key</value>
+  </data>
   <data name="DecodeValidateIssuerLabel" xml:space="preserve">
     <value>Validate issuer</value>
   </data>

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoder.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoder.cs
@@ -78,17 +78,26 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
             TokenParameters tokenParameters,
             TokenResult tokenResult)
         {
-            SigningCredentials? signingCredentials = GetValidationCredentials(tokenParameters);
             var validationParameters = new TokenValidationParameters
             {
-                ValidateIssuerSigningKey = true,
-                IssuerSigningKey = signingCredentials.Key,
-                TryAllIssuerSigningKeys = true,
                 ValidateActor = decodeParameters.ValidateActor,
                 ValidateLifetime = decodeParameters.ValidateLifetime,
                 ValidateIssuer = decodeParameters.ValidateIssuer,
                 ValidateAudience = decodeParameters.ValidateAudience
             };
+            
+            if (decodeParameters.ValidateIssuerSigningKey)
+            {
+                SigningCredentials? signingCredentials = GetValidationCredentials(tokenParameters);
+                validationParameters.ValidateIssuerSigningKey = decodeParameters.ValidateIssuerSigningKey;
+                validationParameters.IssuerSigningKey = signingCredentials.Key;
+                validationParameters.TryAllIssuerSigningKeys = true;
+            }
+            else
+            {
+                // Create a custom signature validator that does nothing so it always passes in this mode
+                validationParameters.SignatureValidator = (token, _) => new JwtSecurityToken(token);
+            }
 
             /// check if the token issuers are part of the user provided issuers
             if (decodeParameters.ValidateIssuer)

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControlViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControlViewModel.cs
@@ -47,6 +47,7 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
             if (ValidateSignature)
             {
                 decoderParamters.ValidateSignature = ValidateSignature;
+                decoderParamters.ValidateIssuerSigningKey = ValidateIssuerSigningKey;
                 decoderParamters.ValidateAudience = ValidateAudience;
                 decoderParamters.ValidateLifetime = ValidateLifetime;
                 decoderParamters.ValidateIssuer = ValidateIssuer;
@@ -95,7 +96,7 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
 
                 }
 
-                DisplayValidationInfoBar();
+                DisplayValidationInfoBar(decoderParamters);
 
 
                 if (ToolSuccessfullyWorked)

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderSettings.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderEncoderSettings.cs
@@ -26,6 +26,15 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
                 defaultValue: false);
 
         /// <summary>
+        /// Define if we need to validate the token issuer signing key
+        /// </summary>
+        public static readonly SettingDefinition<bool> ValidateIssuerSigningKey
+            = new(
+                name: $"{nameof(JwtDecoderEncoderViewModelBase)}.{nameof(ValidateIssuerSigningKey)}",
+                isRoaming: true,
+                defaultValue: true);
+
+        /// <summary>
         /// Define if we need to validate the token issuer
         /// </summary>
         public static readonly SettingDefinition<bool> ValidateIssuer

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
@@ -73,6 +73,15 @@
                 <controls:ExpandableSettingControl.ExpandableContent>
                     <StackPanel Padding="6" Spacing="4" HorizontalAlignment="Stretch">
                         <controls:ExpandableSettingControl
+                            Title="{x:Bind ViewModel.LocalizedStrings.DecodeValidateIssuerSigningKey}">
+                            <controls:ExpandableSettingControl.Icon>
+                                <FontIcon Glyph="&#xF283;" />
+                            </controls:ExpandableSettingControl.Icon>
+                            <ToggleSwitch 
+                                Style="{StaticResource RightAlignedToggleSwitchStyle}" 
+                                IsOn="{x:Bind ViewModel.ValidateIssuerSigningKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                        </controls:ExpandableSettingControl>
+                        <controls:ExpandableSettingControl
                             Title="{x:Bind ViewModel.LocalizedStrings.DecodeValidateIssuerLabel}">
                             <controls:ExpandableSettingControl.Icon>
                                 <FontIcon Glyph="&#xF283;" />

--- a/src/tests/DevToys.Tests/Providers/Tools/JwtDecoderTests.cs
+++ b/src/tests/DevToys.Tests/Providers/Tools/JwtDecoderTests.cs
@@ -346,12 +346,13 @@ namespace DevToys.Tests.Providers.Tools
                 ValidAudiences = new HashSet<string> { "devtoys" },
             };
             var jwtDecoder = new JwtDecoder();
-            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack);
+            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack, out JwtAlgorithm? algorithm);
 
             Assert.IsNotNull(result);
             Assert.IsNull(_validationResult);
             Assert.AreEqual(result.Header, header);
             Assert.AreEqual(result.Payload, payload);
+            Assert.AreEqual(algorithm, JwtAlgorithm.HS256);
         }
 
         #endregion
@@ -472,18 +473,18 @@ namespace DevToys.Tests.Providers.Tools
             };
             var tokenParameters = new TokenParameters
             {
-                TokenAlgorithm = JwtAlgorithm.RS384,
                 Token = await TestDataProvider.GetFileContent("Jwt.RS.ComplexToken.txt"),
                 ValidIssuers = new HashSet<string> { "devtoys" },
                 ValidAudiences = new HashSet<string> { "devtoys" },
             };
             var jwtDecoder = new JwtDecoder();
-            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack);
+            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack, out JwtAlgorithm? algorithm);
 
             Assert.IsNotNull(result);
             Assert.IsNull(_validationResult);
             Assert.AreEqual(result.Header, header);
             Assert.AreEqual(result.Payload, payload);
+            Assert.AreEqual(algorithm, JwtAlgorithm.RS256);
         }
 
         #endregion
@@ -604,18 +605,18 @@ namespace DevToys.Tests.Providers.Tools
             };
             var tokenParameters = new TokenParameters
             {
-                TokenAlgorithm = JwtAlgorithm.PS384,
                 Token = await TestDataProvider.GetFileContent("Jwt.PS.ComplexToken.txt"),
                 ValidIssuers = new HashSet<string> { "devtoys" },
                 ValidAudiences = new HashSet<string> { "devtoys" },
             };
             var jwtDecoder = new JwtDecoder();
-            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack);
+            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack, out JwtAlgorithm? algorithm);
 
             Assert.IsNotNull(result);
             Assert.IsNull(_validationResult);
             Assert.AreEqual(result.Header, header);
             Assert.AreEqual(result.Payload, payload);
+            Assert.AreEqual(algorithm, JwtAlgorithm.PS256);
         }
 
         #endregion
@@ -736,18 +737,18 @@ namespace DevToys.Tests.Providers.Tools
             };
             var tokenParameters = new TokenParameters
             {
-                TokenAlgorithm = JwtAlgorithm.ES384,
                 Token = await TestDataProvider.GetFileContent("Jwt.ES.ComplexToken.txt"),
                 ValidIssuers = new HashSet<string> { "devtoys" },
                 ValidAudiences = new HashSet<string> { "devtoys" },
             };
             var jwtDecoder = new JwtDecoder();
-            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack);
+            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack, out JwtAlgorithm? algorithm);
 
             Assert.IsNotNull(result);
             Assert.IsNull(_validationResult);
             Assert.AreEqual(result.Header, header);
             Assert.AreEqual(result.Payload, payload);
+            Assert.AreEqual(algorithm, JwtAlgorithm.ES256);
         }
 
         #endregion

--- a/src/tests/DevToys.Tests/Providers/Tools/JwtDecoderTests.cs
+++ b/src/tests/DevToys.Tests/Providers/Tools/JwtDecoderTests.cs
@@ -327,6 +327,34 @@ namespace DevToys.Tests.Providers.Tools
             Assert.AreEqual(result.Signature, signature);
         }
 
+        [TestMethod]
+        public async Task JwtDecoder_Decode_Complex_HS_Token_Validate_Actor_Issuer_Audience()
+        {
+            string header = await TestDataProvider.GetFileContent("Jwt.HS.Header.json");
+            string payload = await TestDataProvider.GetFileContent("Jwt.ComplexPayload.json");
+            var decodeParameters = new DecoderParameters
+            {
+                ValidateSignature = true,
+                ValidateIssuerSigningKey = false,
+                ValidateActor = true,
+                ValidateIssuer = true,
+                ValidateAudience = true
+            };
+            var tokenParameters = new TokenParameters
+            {
+                Token = await TestDataProvider.GetFileContent("Jwt.HS.ComplexToken.txt"),
+                ValidIssuers = new HashSet<string> { "devtoys" },
+                ValidAudiences = new HashSet<string> { "devtoys" },
+            };
+            var jwtDecoder = new JwtDecoder();
+            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack);
+
+            Assert.IsNotNull(result);
+            Assert.IsNull(_validationResult);
+            Assert.AreEqual(result.Header, header);
+            Assert.AreEqual(result.Payload, payload);
+        }
+
         #endregion
 
         #region DecodeRS
@@ -428,6 +456,35 @@ namespace DevToys.Tests.Providers.Tools
             Assert.AreEqual(result.Header, header);
             Assert.AreEqual(result.Payload, payload);
             Assert.AreEqual(result.PublicKey, publicKey);
+        }
+
+        [TestMethod]
+        public async Task JwtDecoder_Decode_Complex_RS_Token_Validate_Actor_Issuer_Audience()
+        {
+            string header = await TestDataProvider.GetFileContent("Jwt.RS.Header.json");
+            string payload = await TestDataProvider.GetFileContent("Jwt.ComplexPayload.json");
+            var decodeParameters = new DecoderParameters
+            {
+                ValidateSignature = true,
+                ValidateIssuerSigningKey = false,
+                ValidateActor = true,
+                ValidateIssuer = true,
+                ValidateAudience = true
+            };
+            var tokenParameters = new TokenParameters
+            {
+                TokenAlgorithm = JwtAlgorithm.RS384,
+                Token = await TestDataProvider.GetFileContent("Jwt.RS.ComplexToken.txt"),
+                ValidIssuers = new HashSet<string> { "devtoys" },
+                ValidAudiences = new HashSet<string> { "devtoys" },
+            };
+            var jwtDecoder = new JwtDecoder();
+            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack);
+
+            Assert.IsNotNull(result);
+            Assert.IsNull(_validationResult);
+            Assert.AreEqual(result.Header, header);
+            Assert.AreEqual(result.Payload, payload);
         }
 
         #endregion
@@ -533,6 +590,35 @@ namespace DevToys.Tests.Providers.Tools
             Assert.AreEqual(result.PublicKey, publicKey);
         }
 
+        [TestMethod]
+        public async Task JwtDecoder_Decode_Complex_PS_Token_Validate_Actor_Issuer_Audience()
+        {
+            string header = await TestDataProvider.GetFileContent("Jwt.PS.Header.json");
+            string payload = await TestDataProvider.GetFileContent("Jwt.ComplexPayload.json");
+            var decodeParameters = new DecoderParameters
+            {
+                ValidateSignature = true,
+                ValidateIssuerSigningKey = false,
+                ValidateActor = true,
+                ValidateIssuer = true,
+                ValidateAudience = true
+            };
+            var tokenParameters = new TokenParameters
+            {
+                TokenAlgorithm = JwtAlgorithm.PS384,
+                Token = await TestDataProvider.GetFileContent("Jwt.PS.ComplexToken.txt"),
+                ValidIssuers = new HashSet<string> { "devtoys" },
+                ValidAudiences = new HashSet<string> { "devtoys" },
+            };
+            var jwtDecoder = new JwtDecoder();
+            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack);
+
+            Assert.IsNotNull(result);
+            Assert.IsNull(_validationResult);
+            Assert.AreEqual(result.Header, header);
+            Assert.AreEqual(result.Payload, payload);
+        }
+
         #endregion
 
         #region DecodeES
@@ -634,6 +720,35 @@ namespace DevToys.Tests.Providers.Tools
             Assert.AreEqual(result.Header, header);
             Assert.AreEqual(result.Payload, payload);
             Assert.AreEqual(result.PublicKey, publicKey);
+        }
+
+        [TestMethod]
+        public async Task JwtDecoder_Decode_Complex_ES_Token_Validate_Actor_Issuer_Audience()
+        {
+            string header = await TestDataProvider.GetFileContent("Jwt.ES.Header.json");
+            string payload = await TestDataProvider.GetFileContent("Jwt.ComplexPayload.json");
+            var decodeParameters = new DecoderParameters
+            {
+                ValidateSignature = true,
+                ValidateIssuerSigningKey = false,
+                ValidateActor = true,
+                ValidateIssuer = true,
+                ValidateAudience = true
+            };
+            var tokenParameters = new TokenParameters
+            {
+                TokenAlgorithm = JwtAlgorithm.ES384,
+                Token = await TestDataProvider.GetFileContent("Jwt.ES.ComplexToken.txt"),
+                ValidIssuers = new HashSet<string> { "devtoys" },
+                ValidAudiences = new HashSet<string> { "devtoys" },
+            };
+            var jwtDecoder = new JwtDecoder();
+            TokenResult result = jwtDecoder.DecodeToken(decodeParameters, tokenParameters, DecodingErrorCallBack);
+
+            Assert.IsNotNull(result);
+            Assert.IsNull(_validationResult);
+            Assert.AreEqual(result.Header, header);
+            Assert.AreEqual(result.Payload, payload);
         }
 
         #endregion


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature or enhancement
- [x] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It is impossible to "validate" various parts of a JWT without providing the signature / signing key.

## What is the new behavior?

This PR separates signing key validation as a separate step from overall token validation. As a result, I can choose to validate only the expiration, for example, without providing a key, which is much more convenient.

https://github.com/veler/DevToys/assets/7417301/e3fd3a9d-a04f-4c53-ad62-4532e02853ec

## Other information

If we were starting from scratch, I think it would make sense for the overall validation operation to be called something like `ValidateToken`, and then it could have an option like `ValidateSignature`. However, the latter term is already used for the whole operation (and refers to a persistent setting), so I didn't want to change that. Instead I introduded a new option, `ValidateIssuerSigningKey` (which does align with the `TokenValidationParameters`), and as a result, `ValidateSignature` now has a slightly different meaning. I did update the UI strings to reflect this. Hopefully it's ok!

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)