### PR TITLE
Show additional JWT info

### DIFF
--- a/src/dev/impl/DevToys/DevToys.csproj
+++ b/src/dev/impl/DevToys/DevToys.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Helpers\JsonYaml\Core\DecimalJsonConverter.cs" />
     <Compile Include="Helpers\JsonYaml\Core\DecimalYamlTypeResolver.cs" />
     <Compile Include="ViewModels\Tools\EncodersDecoders\EncodersDecodersGroupToolProvider.cs" />
+    <Compile Include="ViewModels\Tools\EncodersDecoders\JwtDecoderEncoder\JwtClaim.cs" />
     <Compile Include="ViewModels\Tools\EncodersDecoders\JwtDecoderEncoder\JwtEncoder.cs" />
     <Compile Include="ViewModels\Tools\EncodersDecoders\JwtDecoderEncoder\JwtDecoder.cs" />
     <Compile Include="ViewModels\Tools\EncodersDecoders\JwtDecoderEncoder\JwtDecoderControlViewModel.cs" />

--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -766,6 +766,16 @@ namespace DevToys
         public string Expand => _resources.GetString("Expand");
 
         /// <summary>
+        /// Gets the resource ShowInfo.
+        /// </summary>
+        public string ShowInfo => _resources.GetString("ShowInfo");
+
+        /// <summary>
+        /// Gets the resource HideInfo.
+        /// </summary>
+        public string HideInfo => _resources.GetString("HideInfo");
+
+        /// <summary>
         /// Gets the resource FileSelectorBrowseFiles.
         /// </summary>
         public string FileSelectorBrowseFiles => _resources.GetString("FileSelectorBrowseFiles");
@@ -1678,6 +1688,21 @@ namespace DevToys
         public string JwtPayloadLabel => _resources.GetString("JwtPayloadLabel");
 
         /// <summary>
+        /// Gets the resource Type.
+        /// </summary>
+        public string Type => _resources.GetString("Type");
+
+        /// <summary>
+        /// Gets the resource Value.
+        /// </summary>
+        public string Value => _resources.GetString("Value");
+
+        /// <summary>
+        /// Gets the resource DescriptionHeader.
+        /// </summary>
+        public string DescriptionHeader => _resources.GetString("DescriptionHeader");
+
+        /// <summary>
         /// Gets the resource Description.
         /// </summary>
         public string Description => _resources.GetString("Description");
@@ -1896,6 +1921,181 @@ namespace DevToys
         /// Gets the resource InvalidSignatureError.
         /// </summary>
         public string InvalidSignatureError => _resources.GetString("InvalidSignatureError");
+
+        /// <summary>
+        /// Gets the resource NoDescription.
+        /// </summary>
+        public string NoDescription => _resources.GetString("NoDescription");
+
+        /// <summary>
+        /// Gets the resource iss.
+        /// </summary>
+        public string iss => _resources.GetString("iss");
+
+        /// <summary>
+        /// Gets the resource sub.
+        /// </summary>
+        public string sub => _resources.GetString("sub");
+
+        /// <summary>
+        /// Gets the resource aud.
+        /// </summary>
+        public string aud => _resources.GetString("aud");
+
+        /// <summary>
+        /// Gets the resource exp.
+        /// </summary>
+        public string exp => _resources.GetString("exp");
+
+        /// <summary>
+        /// Gets the resource nbf.
+        /// </summary>
+        public string nbf => _resources.GetString("nbf");
+
+        /// <summary>
+        /// Gets the resource iat.
+        /// </summary>
+        public string iat => _resources.GetString("iat");
+
+        /// <summary>
+        /// Gets the resource jti.
+        /// </summary>
+        public string jti => _resources.GetString("jti");
+
+        /// <summary>
+        /// Gets the resource name.
+        /// </summary>
+        public string name => _resources.GetString("name");
+
+        /// <summary>
+        /// Gets the resource given_name.
+        /// </summary>
+        public string given_name => _resources.GetString("given_name");
+
+        /// <summary>
+        /// Gets the resource family_name.
+        /// </summary>
+        public string family_name => _resources.GetString("family_name");
+
+        /// <summary>
+        /// Gets the resource middle_name.
+        /// </summary>
+        public string middle_name => _resources.GetString("middle_name");
+
+        /// <summary>
+        /// Gets the resource nickname.
+        /// </summary>
+        public string nickname => _resources.GetString("nickname");
+
+        /// <summary>
+        /// Gets the resource preferred_username.
+        /// </summary>
+        public string preferred_username => _resources.GetString("preferred_username");
+
+        /// <summary>
+        /// Gets the resource profile.
+        /// </summary>
+        public string profile => _resources.GetString("profile");
+
+        /// <summary>
+        /// Gets the resource picture.
+        /// </summary>
+        public string picture => _resources.GetString("picture");
+
+        /// <summary>
+        /// Gets the resource website.
+        /// </summary>
+        public string website => _resources.GetString("website");
+
+        /// <summary>
+        /// Gets the resource email.
+        /// </summary>
+        public string email => _resources.GetString("email");
+
+        /// <summary>
+        /// Gets the resource email_verified.
+        /// </summary>
+        public string email_verified => _resources.GetString("email_verified");
+
+        /// <summary>
+        /// Gets the resource gender.
+        /// </summary>
+        public string gender => _resources.GetString("gender");
+
+        /// <summary>
+        /// Gets the resource birthdate.
+        /// </summary>
+        public string birthdate => _resources.GetString("birthdate");
+
+        /// <summary>
+        /// Gets the resource zoneinfo.
+        /// </summary>
+        public string zoneinfo => _resources.GetString("zoneinfo");
+
+        /// <summary>
+        /// Gets the resource locale.
+        /// </summary>
+        public string locale => _resources.GetString("locale");
+
+        /// <summary>
+        /// Gets the resource phone_number.
+        /// </summary>
+        public string phone_number => _resources.GetString("phone_number");
+
+        /// <summary>
+        /// Gets the resource phone_number_verified.
+        /// </summary>
+        public string phone_number_verified => _resources.GetString("phone_number_verified");
+
+        /// <summary>
+        /// Gets the resource address.
+        /// </summary>
+        public string address => _resources.GetString("address");
+
+        /// <summary>
+        /// Gets the resource updated_at.
+        /// </summary>
+        public string updated_at => _resources.GetString("updated_at");
+
+        /// <summary>
+        /// Gets the resource azp.
+        /// </summary>
+        public string azp => _resources.GetString("azp");
+
+        /// <summary>
+        /// Gets the resource nonce.
+        /// </summary>
+        public string nonce => _resources.GetString("nonce");
+
+        /// <summary>
+        /// Gets the resource auth_time.
+        /// </summary>
+        public string auth_time => _resources.GetString("auth_time");
+
+        /// <summary>
+        /// Gets the resource at_hash.
+        /// </summary>
+        public string at_hash => _resources.GetString("at_hash");
+
+        /// <summary>
+        /// Gets the resource c_hash.
+        /// </summary>
+        public string c_hash => _resources.GetString("c_hash");
+
+        /// <summary>
+        /// Gets the resource acr.
+        /// </summary>
+        public string acr => _resources.GetString("acr");
+
+        /// <summary>
+        /// Gets the resource amr.
+        /// </summary>
+        public string amr => _resources.GetString("amr");
+
+        /// <summary>
+        /// Gets the resource sub_jwk.
+        /// </summary>
+        public string sub_jwk => _resources.GetString("sub_jwk");
     }
 
     public class LoremIpsumGeneratorStrings : ObservableObject

--- a/src/dev/impl/DevToys/Models/JwtDecoderEncoder/TokenResult.cs
+++ b/src/dev/impl/DevToys/Models/JwtDecoderEncoder/TokenResult.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+using DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder;
 
 namespace DevToys.Models.JwtDecoderEncoder
 {
@@ -10,6 +12,8 @@ namespace DevToys.Models.JwtDecoderEncoder
         public string? Header { get; set; }
 
         public string? Payload { get; set; }
+
+        public IEnumerable<JwtClaim>? Claims { get; set; }
 
         public string? Signature { get; set; }
 

--- a/src/dev/impl/DevToys/Strings/en-US/Common.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/Common.resw
@@ -138,6 +138,12 @@
   <data name="Expand" xml:space="preserve">
     <value>Expand</value>
   </data>
+  <data name="ShowInfo" xml:space="preserve">
+    <value>Show additional info</value>
+  </data>
+  <data name="HideInfo" xml:space="preserve">
+    <value>Hide additional info</value>
+  </data>
   <data name="FileSelectorBrowseFiles" xml:space="preserve">
     <value>Browse files</value>
   </data>

--- a/src/dev/impl/DevToys/Strings/en-US/JwtDecoderEncoder.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/JwtDecoderEncoder.resw
@@ -132,6 +132,15 @@
   <data name="JwtPayloadLabel" xml:space="preserve">
     <value>Payload</value>
   </data>
+  <data name="Type" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="Value" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="DescriptionHeader" xml:space="preserve">
+    <value>Description</value>
+  </data>
   <data name="Description" xml:space="preserve">
     <value>Decode a JWT header, payload and signature</value>
   </data>
@@ -263,5 +272,110 @@
   </data>
   <data name="InvalidSignatureError" xml:space="preserve">
     <value>Invalid Signature</value>
+  </data>
+  <data name="NoDescription" xml:space="preserve">
+    <value>No description</value>
+  </data>
+  <data name="iss" xml:space="preserve">
+    <value>The "iss" (issuer) claim identifies the principal that issued the JWT. The processing of this claim is generally application specific. The "iss" value is a case-sensitive string containing a StringOrURI value. Use of this claim is OPTIONAL.</value>
+  </data>
+  <data name="sub" xml:space="preserve">
+    <value>The "sub" (subject) claim identifies the principal that is the subject of the JWT. The claims in a JWT are normally statements about the subject. The subject value MUST either be scoped to be locally unique in the context of the issuer or be globally unique. The processing of this claim is generally application specific. The "sub" value is a case-sensitive string containing a StringOrURI value. Use of this claim is OPTIONAL.</value>
+  </data>
+  <data name="aud" xml:space="preserve">
+    <value>The "aud" (audience) claim identifies the recipients that the JWT is intended for. Each principal intended to process the JWT MUST identify itself with a value in the audience claim. If the principal processing the claim does not identify itself with a value in the "aud" claim when this claim is present, then the JWT MUST be rejected. In the general case, the "aud" value is an array of case-sensitive strings, each containing a StringOrURI value. In the special case when the JWT has one audience, the "aud" value MAY be a single case-sensitive string containing a StringOrURI value. The interpretation of audience values is generally application specific. Use of this claim is OPTIONAL.</value>
+  </data>
+  <data name="exp" xml:space="preserve">
+    <value>The "exp" (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for processing. The processing of the "exp" claim requires that the current date/time MUST be before the expiration date/time listed in the "exp" claim. Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew. Its value MUST be a number containing a NumericDate value. Use of this claim is OPTIONAL.</value>
+  </data>
+  <data name="nbf" xml:space="preserve">
+    <value>The "nbf" (not before) claim identifies the time before which the JWT MUST NOT be accepted for processing. The processing of the "nbf" claim requires that the current date/time MUST be after or equal to the not-before date/time listed in the "nbf" claim. Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew. Its value MUST be a number containing a NumericDate value. Use of this claim is OPTIONAL.</value>
+  </data>
+  <data name="iat" xml:space="preserve">
+    <value>The "iat" (issued at) claim identifies the time at which the JWT was issued. This claim can be used to determine the age of the JWT. Its value MUST be a number containing a NumericDate value. Use of this claim is OPTIONAL.</value>
+  </data>
+  <data name="jti" xml:space="preserve">
+    <value>The "jti" (JWT ID) claim provides a unique identifier for the JWT. The identifier value MUST be assigned in a manner that ensures that there is a negligible probability that the same value will be accidentally assigned to a different data object; if the application uses multiple issuers, collisions MUST be prevented among values produced by different issuers as well. The "jti" claim can be used to prevent the JWT from being replayed. The "jti" value is a case-sensitive string. Use of this claim is OPTIONAL.</value>
+  </data>
+  <data name="name" xml:space="preserve">
+    <value>End-User's full name in displayable form including all name parts, possibly including titles and suffixes, ordered according to the End-User's locale and preferences.</value>
+  </data>
+  <data name="given_name" xml:space="preserve">
+    <value>Given name(s) or first name(s) of the End-User. Note that in some cultures, people can have multiple given names; all can be present, with the names being separated by space characters.</value>
+  </data>
+  <data name="family_name" xml:space="preserve">
+    <value>Surname(s) or last name(s) of the End-User. Note that in some cultures, people can have multiple family names or no family name; all can be present, with the names being separated by space characters.</value>
+  </data>
+  <data name="middle_name" xml:space="preserve">
+    <value>Middle name(s) of the End-User. Note that in some cultures, people can have multiple middle names; all can be present, with the names being separated by space characters. Also note that in some cultures, middle names are not used.</value>
+  </data>
+  <data name="nickname" xml:space="preserve">
+    <value>Casual name of the End-User that may or may not be the same as the given_name. For instance, a nickname value of Mike might be returned alongside a given_name value of Michael.</value>
+  </data>
+  <data name="preferred_username" xml:space="preserve">
+    <value>Shorthand name by which the End-User wishes to be referred to at the RP, such as janedoe or j.doe. This value MAY be any valid JSON string including special characters such as @, /, or whitespace. The RP MUST NOT rely upon this value being unique.</value>
+  </data>
+  <data name="profile" xml:space="preserve">
+    <value>URL of the End-User's profile page. The contents of this Web page SHOULD be about the End-User.</value>
+  </data>
+  <data name="picture" xml:space="preserve">
+    <value>URL of the End-User's profile picture. This URL MUST refer to an image file (for example, a PNG, JPEG, or GIF image file), rather than to a Web page containing an image. Note that this URL SHOULD specifically reference a profile photo of the End-User suitable for displaying when describing the End-User, rather than an arbitrary photo taken by the End-User.</value>
+  </data>
+  <data name="website" xml:space="preserve">
+    <value>URL of the End-User's Web page or blog. This Web page SHOULD contain information published by the End-User or an organization that the End-User is affiliated with.</value>
+  </data>
+  <data name="email" xml:space="preserve">
+    <value>End-User's preferred e-mail address. Its value MUST conform to the RFC 5322 addr-spec syntax. The RP MUST NOT rely upon this value being unique.</value>
+  </data>
+  <data name="email_verified" xml:space="preserve">
+    <value>True if the End-User's e-mail address has been verified; otherwise false. When this Claim Value is true, this means that the OP took affirmative steps to ensure that this e-mail address was controlled by the End-User at the time the verification was performed. The means by which an e-mail address is verified is context-specific, and dependent upon the trust framework or contractual agreements within which the parties are operating.</value>
+  </data>
+  <data name="gender" xml:space="preserve">
+    <value>End-User's gender. Values defined by this specification are female and male. Other values MAY be used when neither of the defined values are applicable.</value>
+  </data>
+  <data name="birthdate" xml:space="preserve">
+    <value>End-User's birthday, represented as an ISO 8601:2004 YYYY-MM-DD format. The year MAY be 0000, indicating that it is omitted. To represent only the year, YYYY format is allowed. Note that depending on the underlying platform's date related function, providing just year can result in varying month and day, so the implementers need to take this factor into account to correctly process the dates.</value>
+  </data>
+  <data name="zoneinfo" xml:space="preserve">
+    <value>String from zoneinfo time zone database representing the End-User's time zone. For example, Europe/Paris or America/Los_Angeles.</value>
+  </data>
+  <data name="locale" xml:space="preserve">
+    <value>End-User's locale, represented as a BCP47 [RFC5646] language tag. This is typically an ISO 639-1 Alpha-2 language code in lowercase and an ISO 3166-1 Alpha-2 country code in uppercase, separated by a dash. For example, en-US or fr-CA. As a compatibility note, some implementations have used an underscore as the separator rather than a dash, for example, en_US; Relying Parties MAY choose to accept this locale syntax as well.</value>
+  </data>
+  <data name="phone_number" xml:space="preserve">
+    <value>End-User's preferred telephone number. E.164 is RECOMMENDED as the format of this Claim, for example, +1 (425) 555-1212 or +56 (2) 687 2400. If the phone number contains an extension, it is RECOMMENDED that the extension be represented using the RFC 3966 extension syntax, for example, +1 (604) 555-1234;ext=5678.</value>
+  </data>
+  <data name="phone_number_verified" xml:space="preserve">
+    <value>True if the End-User's phone number has been verified; otherwise false. When this Claim Value is true, this means that the OP took affirmative steps to ensure that this phone number was controlled by the End-User at the time the verification was performed. The means by which a phone number is verified is context-specific, and dependent upon the trust framework or contractual agreements within which the parties are operating. When true, the phone_number Claim MUST be in E.164 format and any extensions MUST be represented in RFC 3966 format.</value>
+  </data>
+  <data name="address" xml:space="preserve">
+    <value>End-User's preferred postal address. The value of the address member is a JSON [RFC4627] structure.</value>
+  </data>
+  <data name="updated_at" xml:space="preserve">
+    <value>Time the End-User's information was last updated. Its value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time.</value>
+  </data>
+  <data name="azp" xml:space="preserve">
+    <value>Authorized party - the party to which the ID Token was issued. If present, it MUST contain the OAuth 2.0 Client ID of this party. This Claim is only needed when the ID Token has a single audience value and that audience is different than the authorized party. It MAY be included even when the authorized party is the same as the sole audience. The azp value is a case sensitive string containing a StringOrURI value.</value>
+  </data>
+  <data name="nonce" xml:space="preserve">
+    <value>String value used to associate a Client session with an ID Token, and to mitigate replay attacks. The value is passed through unmodified from the Authentication Request to the ID Token. If present in the ID Token, Clients MUST verify that the nonce Claim Value is equal to the value of the nonce parameter sent in the Authentication Request. If present in the Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token with the Claim Value being the nonce value sent in the Authentication Request. Authorization Servers SHOULD perform no other processing on nonce values used. The nonce value is a case sensitive string.</value>
+  </data>
+  <data name="auth_time" xml:space="preserve">
+    <value>Time when the End-User authentication occurred. Its value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time. When a max_age request is made or when auth_time is requested as an Essential Claim, then this Claim is REQUIRED; otherwise, its inclusion is OPTIONAL. (The auth_time Claim semantically corresponds to the OpenID 2.0 PAPE auth_time response parameter.)</value>
+  </data>
+  <data name="at_hash" xml:space="preserve">
+    <value>Access Token hash value. Its value is the base64url encoding of the left-most half of the hash of the octets of the ASCII representation of the access_token value, where the hash algorithm used is the hash algorithm used in the alg Header Parameter of the ID Token's JOSE Header. For instance, if the alg is RS256, hash the access_token value with SHA-256, then take the left-most 128 bits and base64url encode them. The at_hash value is a case sensitive string.</value>
+  </data>
+  <data name="c_hash" xml:space="preserve">
+    <value>Code hash value. Its value is the base64url encoding of the left-most half of the hash of the octets of the ASCII representation of the code value, where the hash algorithm used is the hash algorithm used in the alg Header Parameter of the ID Token's JOSE Header. For instance, if the alg is HS512, hash the code value with SHA-512, then take the left-most 256 bits and base64url encode them. The c_hash value is a case sensitive string. If the ID Token is issued from the Authorization Endpoint with a code, which is the case for the response_type values code id_token and code id_token token, this is REQUIRED; otherwise, its inclusion is OPTIONAL.</value>
+  </data>
+  <data name="acr" xml:space="preserve">
+    <value>Authentication Context Class Reference. String specifying an Authentication Context Class Reference value that identifies the Authentication Context Class that the authentication performed satisfied. The value "0" indicates the End-User authentication did not meet the requirements of ISO/IEC 29115 level 1. Authentication using a long-lived browser cookie, for instance, is one example where the use of "level 0" is appropriate. Authentications with level 0 SHOULD NOT be used to authorize access to any resource of any monetary value. (This corresponds to the OpenID 2.0 PAPE nist_auth_level 0.) An absolute URI or an RFC 6711 registered name SHOULD be used as the acr value; registered names MUST NOT be used with a different meaning than that which is registered. Parties using this claim will need to agree upon the meanings of the values used, which may be context-specific. The acr value is a case sensitive string.</value>
+  </data>
+  <data name="amr" xml:space="preserve">
+    <value>Authentication Methods References. JSON array of strings that are identifiers for authentication methods used in the authentication. For instance, values might indicate that both password and OTP authentication methods were used. Parties using this claim will need to agree upon the meanings of the values used, which may be context-specific. The amr value is an array of case sensitive strings.</value>
+  </data>
+  <data name="sub_jwk" xml:space="preserve">
+    <value>Public key used to check the signature of an ID Token issued by a Self-Issued OpenID Provider. The key is a bare key in JWK format (not an X.509 certificate value). The sub_jwk value is a JSON object. Use of the sub_jwk Claim is NOT RECOMMENDED when the OP is not Self-Issued.</value>
   </data>
 </root>

--- a/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml
+++ b/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml
@@ -18,6 +18,8 @@
         <converters:InvertedBooleanConverter x:Key="InvertedBooleanConverter"/>
         <converters:BooleanToTextWrappingConverter x:Key="BooleanToTextWrappingConverter" TextWrappingOnTrue="Wrap" TextWrappingOnFalse="NoWrap"/>
         <converters:BooleanToIntegerConverter x:Key="ReadOnlyToClearButtonTabIndexConverter" ValueOnTrue="3" ValueOnFalse="0"/>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <converters:BooleanToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter" IsInverted="True"/>
     </UserControl.Resources>
 
     <Grid>
@@ -124,7 +126,8 @@
             x:Name="CodeEditorCoreContainer"
             Grid.Row="1"
             Grid.Column="0"
-            Grid.ColumnSpan="2">
+            Grid.ColumnSpan="2"
+            Visibility="{x:Bind ShowInfoContent, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
             <!--<monaco:CodeEditorCore
                 Grid.Row="1"
                 Grid.Column="0"
@@ -150,7 +153,7 @@
             Grid.Row="1"
             Grid.Column="0"
             Grid.ColumnSpan="2"
-            Visibility="Collapsed"
+            Visibility="{x:Bind ShowInfoContent, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
             Content="{x:Bind InfoContent}">
         </ContentControl>
         <TextBlock

--- a/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml
+++ b/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml
@@ -61,6 +61,17 @@
                 <FontIcon x:Name="ExpandButtonIcon" Glyph="&#xF15F;"/>
             </Button>
             <Button
+                x:Name="InfoButton"
+                x:DeferLoadStrategy="Lazy"
+                Visibility="Collapsed"
+                TabIndex="0"
+                Margin="8,0,0,0"
+                ToolTipService.ToolTip="{Binding Instance.Common.ShowInfo, Mode=OneTime, Source={StaticResource LanguageManager}}"
+                AutomationProperties.Name="{Binding Instance.Common.ShowInfo, Mode=OneTime, Source={StaticResource LanguageManager}}"
+                Click="InfoButton_Click">
+                <FontIcon Glyph="&#xF4A3;"/>
+            </Button>
+            <Button
                 x:Name="PasteButton"
                 x:DeferLoadStrategy="Lazy"
                 Visibility="Collapsed"
@@ -126,6 +137,22 @@
                 DiffRightText="{x:Bind DiffRightText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 AutomationProperties.LabeledBy="{x:Bind HeaderTextBlock}"/>-->
         </Grid>
+        <Border
+            x:Name="CodeEditorSizeFit"
+            Grid.Row="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            SizeChanged="CodeEditorSizeFit_SizeChanged"/>
+        <ContentControl
+            x:Name="InfoGrid"
+            Grid.Row="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Visibility="Collapsed"
+            Content="{x:Bind InfoContent}">
+        </ContentControl>
         <TextBlock
             Grid.Row="1"
             Grid.Column="0"

--- a/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml.cs
+++ b/src/dev/impl/DevToys/UI/Controls/CodeEditor.xaml.cs
@@ -219,7 +219,18 @@ namespace DevToys.UI.Controls
             set => SetValue(InfoContentProperty, value);
         }
 
-        private bool ShowInfoContent { get; set; }
+        public static readonly DependencyProperty ShowInfoContentProperty
+            = DependencyProperty.Register(
+                nameof(ShowInfoContent),
+                typeof(bool),
+                typeof(CodeEditor),
+                new PropertyMetadata(false));
+
+        public bool ShowInfoContent
+        {
+            get => (bool)GetValue(ShowInfoContentProperty);
+            set => SetValue(ShowInfoContentProperty, value);
+        }
 
         public CodeEditor()
         {
@@ -521,7 +532,6 @@ namespace DevToys.UI.Controls
             // when being expanded/collapsed. 
             bool showInfo = ShowInfoContent;
             ShowInfoContent = false;
-            UpdateInfoVisibility();
 
             IsExpanded = !IsExpanded;
             ExpandedChanged?.Invoke(this, EventArgs.Empty);
@@ -541,31 +551,13 @@ namespace DevToys.UI.Controls
             Window.Current.Dispatcher.RunIdleAsync(_ =>
             {
                 ShowInfoContent = showInfo;
-                UpdateInfoVisibility();
             });
         }
 
         private void InfoButton_Click(object sender, RoutedEventArgs e)
         {
             ShowInfoContent = !ShowInfoContent;
-
             ToolTipService.SetToolTip(GetInfoButton(), ShowInfoContent ? LanguageManager.Instance.Common.HideInfo : LanguageManager.Instance.Common.ShowInfo);
-
-            UpdateInfoVisibility();
-        }
-
-        private void UpdateInfoVisibility()
-        {
-            if (ShowInfoContent)
-            {
-                CodeEditorCoreContainer.Visibility = Visibility.Collapsed;
-                InfoGrid.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                CodeEditorCoreContainer.Visibility = Visibility.Visible;
-                InfoGrid.Visibility = Visibility.Collapsed;
-            }
         }
 
         private async void PasteButton_Click(object sender, RoutedEventArgs e)

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtClaim.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtClaim.cs
@@ -26,6 +26,8 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
 
         #region Statics
 
+        // We need a direct reference to the ResourceLoader here, rather than going through LanguageManager.Instance.JwtDecoderEncoder,
+        // so that we can generically load any resource by name with GetString, rather than having to use the properties.
         private static readonly ResourceLoader Resources = ResourceLoader.GetForViewIndependentUse(nameof(JwtDecoderEncoder));
 
         private static bool TryGetDescription(string claim, out string? description)

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtClaim.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtClaim.cs
@@ -1,0 +1,50 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Windows.ApplicationModel.Resources;
+
+namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
+{
+    public class JwtClaim
+    {
+        private readonly Claim _claim;
+        
+        public JwtClaim(Claim claim) => _claim = claim;
+
+        public string Type => _claim.Type;
+        
+        public string Value => DateFields.Contains(Type) && long.TryParse(_claim.Value, out long value)
+            ? DateTimeOffset.FromUnixTimeSeconds(value).ToLocalTime().ToString()
+            : _claim.Value;
+
+        public string? Description =>
+            TryGetDescription(_claim.Type.ToLowerInvariant(), out string? description)
+                ? description
+                : LanguageManager.Instance.JwtDecoderEncoder.NoDescription;
+
+        #region Statics
+
+        private static readonly ResourceLoader Resources = ResourceLoader.GetForViewIndependentUse(nameof(JwtDecoderEncoder));
+
+        private static bool TryGetDescription(string claim, out string? description)
+        {
+            string descriptionResource = Resources.GetString(claim);
+            if (string.IsNullOrEmpty(descriptionResource))
+            {
+                description = null;
+                return false;
+            }
+            else
+            {
+                description = descriptionResource;
+                return true;
+            }
+        }
+
+        private static readonly List<string> DateFields = new() { "exp", "nbf", "iat", "auth_time", "updated_at" };
+
+        #endregion
+    }
+}

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoder.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoder.cs
@@ -64,6 +64,8 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
                         return null;
                     }
                 }
+
+                tokenResult.Claims = jwtSecurityToken.Claims.Select(c => new JwtClaim(c));
             }
             catch (Exception exception)
             {

--- a/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControlViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControlViewModel.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using DevToys.Api.Core;
@@ -19,8 +20,18 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
     public sealed class JwtDecoderControlViewModel : JwtDecoderEncoderViewModelBase, IToolViewModel, IRecipient<JwtJobAddedMessage>
     {
         private readonly JwtDecoder _decoder;
+        private IEnumerable<JwtClaim>? _claims;
 
         public Type View { get; } = typeof(JwtDecoderControl);
+
+        internal IEnumerable<JwtClaim>? Claims
+        {
+            get => _claims;
+            set
+            {
+                SetProperty(ref _claims, value);
+            }
+        }
 
         [ImportingConstructor]
         public JwtDecoderControlViewModel(
@@ -95,6 +106,7 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
 
                 Header = result.Header;
                 Payload = result.Payload;
+                Claims = result.Claims;
 
                 DisplayValidationInfoBar(decoderParamters);
 
@@ -121,6 +133,7 @@ namespace DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder
         private void ClearPayload()
         {
             Payload = string.Empty;
+            Claims = null;
         }
     }
 }

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
@@ -9,8 +9,7 @@
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:DevToys="using:DevToys"
     xmlns:controls="using:DevToys.UI.Controls"
-    xmlns:converters="using:DevToys.UI.Converters"
-    Loaded="OnLoaded">
+    xmlns:converters="using:DevToys.UI.Converters">
 
     <UserControl.Resources>
         <converters:NullToBooleanConverter x:Name="NullToVisible" IsInverted="True"/>
@@ -206,11 +205,11 @@
                     CornerRadius="{ThemeResource ControlCornerRadius}"
                     Background="{ThemeResource TextControlBackground}">
                     <toolkit:DataGrid
-                        x:Name="InfoDataGrid"
                         AutoGenerateColumns="False"
                         ItemsSource="{x:Bind ViewModel.Claims, Mode=OneWay}"
                         AlternatingRowBackground="{ThemeResource TextControlButtonBackgroundPressed}"
-                        RowDetailsTemplate="{StaticResource InfoDataGridRowDetailsTemplate}">
+                        RowDetailsTemplate="{StaticResource InfoDataGridRowDetailsTemplate}"
+                        FontFamily="{x:Bind InfoDataGridFontFamily, Mode=OneWay}">
                         <toolkit:DataGrid.Resources>
                             <!-- This key just has to exist to remove the default coloring of the column headers and make them look like the rows. -->
                             <SolidColorBrush x:Key="DataGridColumnHeaderBackgroundColor"/>

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml
@@ -9,7 +9,8 @@
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:DevToys="using:DevToys"
     xmlns:controls="using:DevToys.UI.Controls"
-    xmlns:converters="using:DevToys.UI.Converters">
+    xmlns:converters="using:DevToys.UI.Converters"
+    Loaded="OnLoaded">
 
     <UserControl.Resources>
         <converters:NullToBooleanConverter x:Name="NullToVisible" IsInverted="True"/>
@@ -23,6 +24,17 @@
             <Setter Property="MinHeight" Value="{StaticResource ExpanderMinHeight}" />
             <Setter Property="Padding" Value="{StaticResource ExpanderContentPadding}" />
         </Style>
+
+        <!-- Details row template for Claims info DataGrid -->
+        <DataTemplate x:Key="InfoDataGridRowDetailsTemplate">
+            <!-- Need a border because TextBlock doesn't have background -->
+            <Border Background="{ThemeResource TextControlBackgroundFocused}">
+                <TextBlock
+                    Text="{Binding Description}"
+                    Padding="20,10,10,10"
+                    TextWrapping="Wrap"/>
+            </Border>
+        </DataTemplate>
     </UserControl.Resources>
 
     <Grid x:Name="JwtDecoderGrid" Margin="0,0,0,16" RowSpacing="12">
@@ -186,7 +198,45 @@
             CodeLanguage="json"
             IsReadOnly="True"
             AllowExpand="True"
-            ExpandedChanged="PayloadCodeEditor_ExpandedChanged"/>
+            ExpandedChanged="PayloadCodeEditor_ExpandedChanged">
+            <controls:CodeEditor.InfoContent>
+                <Border
+                    BorderThickness="1" 
+                    BorderBrush="{ThemeResource TextControlBorderBrush}" 
+                    CornerRadius="{ThemeResource ControlCornerRadius}"
+                    Background="{ThemeResource TextControlBackground}">
+                    <toolkit:DataGrid
+                        x:Name="InfoDataGrid"
+                        AutoGenerateColumns="False"
+                        ItemsSource="{x:Bind ViewModel.Claims, Mode=OneWay}"
+                        AlternatingRowBackground="{ThemeResource TextControlButtonBackgroundPressed}"
+                        RowDetailsTemplate="{StaticResource InfoDataGridRowDetailsTemplate}">
+                        <toolkit:DataGrid.Resources>
+                            <!-- This key just has to exist to remove the default coloring of the column headers and make them look like the rows. -->
+                            <SolidColorBrush x:Key="DataGridColumnHeaderBackgroundColor"/>
+                        </toolkit:DataGrid.Resources>
+                        <!-- Claims Type column -->
+                        <toolkit:DataGrid.Columns>
+                            <toolkit:DataGridTextColumn Header="{x:Bind ViewModel.LocalizedStrings.Type}" Width="*" Binding="{Binding Type}">
+                                <toolkit:DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="TextWrapping" Value="Wrap" />
+                                    </Style>
+                                </toolkit:DataGridTextColumn.ElementStyle>
+                            </toolkit:DataGridTextColumn>
+                            <!--Claims Value column-->
+                            <toolkit:DataGridTextColumn Header="{x:Bind ViewModel.LocalizedStrings.Value}" Width="2*" Binding="{Binding Value}">
+                                <toolkit:DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="TextWrapping" Value="Wrap" />
+                                    </Style>
+                                </toolkit:DataGridTextColumn.ElementStyle>
+                            </toolkit:DataGridTextColumn>
+                        </toolkit:DataGrid.Columns>
+                    </toolkit:DataGrid>
+                </Border>
+            </controls:CodeEditor.InfoContent>
+        </controls:CodeEditor>
         <Grid
             x:Name="SignatureGrid"
             Grid.Row="4"

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml.cs
@@ -2,14 +2,20 @@
 
 using System;
 using System.Composition;
+using DevToys.Api.Core.Settings;
+using DevToys.Core.Settings;
 using DevToys.ViewModels.Tools.EncodersDecoders.JwtDecoderEncoder;
+using Microsoft.Toolkit.Uwp.UI.Controls.Primitives;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 
 namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
 {
     public sealed partial class JwtDecoderControl : UserControl
     {
+        private readonly ISettingsProvider? _settingsProvider;
+
         public static readonly DependencyProperty ViewModelProperty
            = DependencyProperty.Register(
                nameof(ViewModel),
@@ -33,10 +39,18 @@ namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
 
         public JwtDecoderControl()
         {
+            _settingsProvider = Shared.Core.MefComposer.Provider.Import<ISettingsProvider>();
+            _settingsProvider.SettingChanged += SettingsProvider_SettingChanged;
+
             InitializeComponent();
         }
 
-        private void PayloadCodeEditor_ExpandedChanged(object sender, System.EventArgs e)
+        private void SettingsProvider_SettingChanged(object sender, SettingChangedEventArgs e)
+        {
+            ApplySettings();
+        }
+
+        private void PayloadCodeEditor_ExpandedChanged(object sender, EventArgs e)
         {
             IsExpanded = !IsExpanded;
 
@@ -49,6 +63,23 @@ namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
             {
                 ExpandedChanged?.Invoke(PayloadCodeEditor, EventArgs.Empty);
                 JwtDecoderGrid.Children.Add(PayloadCodeEditor);
+            }
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            ApplySettings();
+        }
+
+        private void ApplySettings()
+        {
+            if (_settingsProvider is not null && InfoDataGrid is not null)
+            {
+                FontFamily fontFamily = new(_settingsProvider.GetSetting(PredefinedSettings.TextEditorFont));
+                InfoDataGrid.FontFamily = fontFamily;
+                Style style = new(typeof(DataGridColumnHeader));
+                style.Setters.Add(new Setter(FontFamilyProperty, fontFamily));
+                InfoDataGrid.ColumnHeaderStyle = style;
             }
         }
     }

--- a/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml.cs
+++ b/src/dev/impl/DevToys/Views/Tools/EncodersDecoders/JwtDecoderEncoder/JwtDecoderControl.xaml.cs
@@ -14,7 +14,7 @@ namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
 {
     public sealed partial class JwtDecoderControl : UserControl
     {
-        private readonly ISettingsProvider? _settingsProvider;
+        private readonly ISettingsProvider _settingsProvider;
 
         public static readonly DependencyProperty ViewModelProperty
            = DependencyProperty.Register(
@@ -37,10 +37,25 @@ namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
             set => SetValue(ViewModelProperty, value);
         }
 
+        public static readonly DependencyProperty InfoDataGridFontFamilyProperty
+            = DependencyProperty.Register(
+                nameof(FontFamily),
+                typeof(JwtDecoderControlViewModel),
+                typeof(JwtDecoderControl),
+                new PropertyMetadata(null));
+
+        public FontFamily InfoDataGridFontFamily
+        {
+            get => (FontFamily)GetValue(InfoDataGridFontFamilyProperty);
+            set => SetValue(InfoDataGridFontFamilyProperty, value);
+        }
+
         public JwtDecoderControl()
         {
             _settingsProvider = Shared.Core.MefComposer.Provider.Import<ISettingsProvider>();
             _settingsProvider.SettingChanged += SettingsProvider_SettingChanged;
+
+            ApplySettings();
 
             InitializeComponent();
         }
@@ -66,21 +81,9 @@ namespace DevToys.Views.Tools.EncodersDecoders.JwtDecoderEncoder
             }
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
-        {
-            ApplySettings();
-        }
-
         private void ApplySettings()
         {
-            if (_settingsProvider is not null && InfoDataGrid is not null)
-            {
-                FontFamily fontFamily = new(_settingsProvider.GetSetting(PredefinedSettings.TextEditorFont));
-                InfoDataGrid.FontFamily = fontFamily;
-                Style style = new(typeof(DataGridColumnHeader));
-                style.Setters.Add(new Setter(FontFamilyProperty, fontFamily));
-                InfoDataGrid.ColumnHeaderStyle = style;
-            }
+            InfoDataGridFontFamily = new FontFamily(_settingsProvider.GetSetting(PredefinedSettings.TextEditorFont));
         }
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature or enhancement
- [x] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Numbers: #607 and #670

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR adds the ability to show additional information about a decoded JWT. Key features are...
 - Each top-level property of the JWT is shown in a table with the key in one column and the value in another.
 - The values of date/time fields are shown in human-readable formats (instead of timestamp/long).
 - Clicking the row for a given field will display an explanation about that field (if it is a known/documented JWT claim).
   - There are descriptions for claims from [RFC 7519 Section 4.1](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1) and the [OpenID Connect Core Section 5.1, 2, 3.3.2.11, and 7.4](https://openid.net/specs/openid-connect-core-1_0.html) using the [IANA Registry](https://www.iana.org/assignments/jwt/jwt.xhtml#claims) as a source of truth.

## Other information

There are several things to mention about this implementation.
 - In order to inject the information, I went with a slightly different approach than was suggested. Rather than having the parent control inject the info button, it is part of the standard `CodeEditor`. However the info control itself can be set via a DependencyProperty, and the `CodeEditor` will show whatever's there. 
 - I struggled with how to disply the claim descriptions. They're usually very long, and I had trouble fitting them in a third column in the table. My options were (a) allow the grid to expand as wide as it wants, putting the info on one line and marking it hard to read, or (b) keep the grid width fixed and make the description wrap, which ended causing each row to consume too much vertical space. I thought about some other alternatives (truncating the description until clicked), but the bigger issue here is an apparent bug in the Toolkit DataGrid which causes rows taller than one line of text to have trouble rendering. I can upload a video of this if anyone's curious.
  Luckily, I ran across [Row Details](https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/blob/main/docs/controls/datagrid_guidance/rowdetails.md) and I thought it would be the perfect compromise of having a nice clean grid initially with easy access to the descriptions. One quirk here is that I would expect clicking the row again to toggle the details off, but it doesn't. Maybe some special code can be added in the future to do that.
 - Along the same lines, I noticed that the grid doesn't respond perfectly to live theme changes. You have to scroll up and down to get all the rows to convert. I'm guessing this is another bug and maybe related to virtualization. However, I think it's ok since it's a rare case (changing theme while this control is open), and it eventually fixes itself.
 - Finally, there is some funny handling related to sizing. In addition to the technique used in the `CustomTextBox` (a `Border` whose size controls the `TextBox`'s size), I also had to add another trick. When expanding or collapsing the addiitonal info view, I quickly toggle on the `CodeEditor`. Without this, the `Border` has the wrong size. This does occasionally create a very small visual artifact, but it's the only way I could get the sizing to be solid.

https://github.com/veler/DevToys/assets/7417301/fa855d51-5627-45c2-9b1b-44b70c12b587

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)