### PR TITLE
Enhance label readability in Cron Parser

### DIFF
--- a/src/dev/impl/DevToys/Strings/en-US/CRONParser.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/CRONParser.resw
@@ -124,7 +124,7 @@
     <value>Configuration</value>
   </data>
   <data name="UseSecondsDescription" xml:space="preserve">
-    <value>Choose whatever Cron expression should includes seconds in its definition</value>
+    <value>Choose whether the Cron expression should include seconds in its definition</value>
   </data>
   <data name="UseSecondsTitle" xml:space="preserve">
     <value>Cron Mode</value>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The CronParser tool has the following label: 

"Choose whatever Cron expression should includes seconds in its definition"

## What is the new behavior?

Changed it to 

"Choose whether the Cron expression should include seconds in its definition"


<!-- Please describe the behavior or changes that are being added by this PR. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [ ] Did you build the app and test your changes?
- [x] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [] Did you verify that the change work in Release build configuration
- [] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [ ] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)