### PR TITLE
Improved Hot Reload support

### DIFF
--- a/src/app/dev/DevToys.Blazor/Pages/SubPages/ToolPage.razor
+++ b/src/app/dev/DevToys.Blazor/Pages/SubPages/ToolPage.razor
@@ -61,12 +61,6 @@
                                 <TextBlock Text="@ViewModel.GetFavoriteButtonText(ViewModel.IsSelectedMenuItemAFavoriteTool)" />
                             </StackPanel>
                         </Button>
-                        <Button IsVisible="@Debugger.IsAttached"
-                                Appearance="ButtonAppearance.Stealth"
-                                ToolTip="Hot reload"
-                                @onclick="@OnHotReloadButtonClick">
-                            <FontIcon Glyph="@('\uEF68')" Style="color: red;" />
-                        </Button>
                     </StackPanel>
                 </GridCell>
 

--- a/src/app/dev/DevToys.Blazor/Pages/SubPages/ToolPage.razor.cs
+++ b/src/app/dev/DevToys.Blazor/Pages/SubPages/ToolPage.razor.cs
@@ -1,6 +1,7 @@
 ﻿using DevToys.Blazor.Components;
 using DevToys.Blazor.Core.Services;
 using DevToys.Business.ViewModels;
+using DevToys.Core.Debugger;
 using DevToys.Core.Tools.ViewItems;
 
 namespace DevToys.Blazor.Pages.SubPages;
@@ -16,6 +17,9 @@ public partial class ToolPage : MefComponentBase, IDisposable
     [Import]
     internal ToolPageViewModel ViewModel { get; set; } = default!;
 
+    [Import]
+    internal HotReloadService HotReloadService { get; set; } = default!;
+
     [Parameter]
     public GuiToolViewItem? GuiToolViewItem { get; set; }
 
@@ -29,6 +33,7 @@ public partial class ToolPage : MefComponentBase, IDisposable
     {
         base.OnInitialized();
         DialogService.CloseDialogRequested += DialogService_CloseDialogRequested;
+        HotReloadService.HotReloadRequestUpdateApplication += OnHotReloadRequestUpdateApplication;
     }
 
     protected override void OnParametersSet()
@@ -50,6 +55,7 @@ public partial class ToolPage : MefComponentBase, IDisposable
 
     public void Dispose()
     {
+        HotReloadService.HotReloadRequestUpdateApplication -= OnHotReloadRequestUpdateApplication;
         DialogService.CloseDialogRequested -= DialogService_CloseDialogRequested;
         if (ViewModel.ToolView is not null)
         {
@@ -100,7 +106,7 @@ public partial class ToolPage : MefComponentBase, IDisposable
         IndexPage.StateHasChanged();
     }
 
-    private void OnHotReloadButtonClick()
+    private void OnHotReloadRequestUpdateApplication(object? sender, HotReloadEventArgs e)
     {
         ViewModel.RebuildViewCommand.Execute(null);
     }

--- a/src/app/dev/DevToys.Core/Debugger/HotReloadEventArgs.cs
+++ b/src/app/dev/DevToys.Core/Debugger/HotReloadEventArgs.cs
@@ -1,0 +1,11 @@
+﻿namespace DevToys.Core.Debugger;
+
+public sealed class HotReloadEventArgs : EventArgs
+{
+    internal HotReloadEventArgs(Type[]? types)
+    {
+        Types = types;
+    }
+
+    public Type[]? Types { get; }
+}

--- a/src/app/dev/DevToys.Core/Debugger/HotReloadService.cs
+++ b/src/app/dev/DevToys.Core/Debugger/HotReloadService.cs
@@ -1,0 +1,49 @@
+﻿// This attribute will make the .NET runtime invoke the ClearCache and UpdateApplication methods when a hot reload
+// is requested from Visual Studio / VS Code or Rider.
+// More info: https://learn.microsoft.com/en-us/visualstudio/debugger/hot-reload-metadataupdatehandler
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(DevToys.Core.Debugger.HotReloadService))]
+
+namespace DevToys.Core.Debugger;
+
+[Export(typeof(HotReloadService))]
+public sealed class HotReloadService
+{
+    [ImportingConstructor]
+    public HotReloadService()
+    {
+        internalHotReloadRequestClearCache += (sender, args) => HotReloadRequestClearCache?.Invoke(sender, args);
+        internalHotReloadRequestUpdateApplication += (sender, args) => HotReloadRequestUpdateApplication?.Invoke(sender, args);
+    }
+
+    public EventHandler<HotReloadEventArgs>? HotReloadRequestClearCache;
+
+    public EventHandler<HotReloadEventArgs>? HotReloadRequestUpdateApplication;
+
+    private static EventHandler<HotReloadEventArgs>? internalHotReloadRequestClearCache;
+
+    private static EventHandler<HotReloadEventArgs>? internalHotReloadRequestUpdateApplication;
+
+    /// <summary>
+    /// Hot reload handler invoked by thanks to the MetadataUpdateHandler attribute.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Invoked by .NET runtime on Hot Reload.")]
+    private static void ClearCache(Type[]? types)
+    {
+        if (System.Diagnostics.Debugger.IsAttached)
+        {
+            internalHotReloadRequestClearCache?.Invoke(null, new HotReloadEventArgs(types));
+        }
+    }
+
+    /// <summary>
+    /// Hot reload handler invoked by thanks to the MetadataUpdateHandler attribute.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Invoked by .NET runtime on Hot Reload.")]
+    private static void UpdateApplication(Type[]? types)
+    {
+        if (System.Diagnostics.Debugger.IsAttached)
+        {
+            internalHotReloadRequestUpdateApplication?.Invoke(null, new HotReloadEventArgs(types));
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [X] Other: Internal support for Hot Reload

## What is the current behavior?

DevToys 2.0 was supporting Hot Reload through a button added to the UI that forces the app to rebuild the view of a `IGuiTool`. This required the developer to explicitly click on this "Hot reload" button.

## What is the new behavior?

We now use `System.Reflection.Metadata.MetadataUpdateHandler` to get notified at runtime that Hot Reload occurred, and we reload the view of the active tool when it happens.
More info: https://learn.microsoft.com/en-us/visualstudio/debugger/hot-reload-metadataupdatehandler

## Other information


https://github.com/veler/DevToys/assets/3747805/e8ab8016-65f4-4b58-8d1e-91d3c8fa7020



## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [X] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)