### PR TITLE
Enabled Hover capability on Monaco Editor and fixed JSON serialization issue.

### DIFF
--- a/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/Monaco/TextModel.cs
+++ b/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/Monaco/TextModel.cs
@@ -291,7 +291,7 @@ public class TextModel
     /// @return An array containing the new decorations identifiers.
     /// </summary>
     public ValueTask<string[]> DeltaDecorationsAsync(IJSRuntime runtime, string[] oldDecorations, ModelDeltaDecoration[] newDecorations, int? ownerId)
-        => runtime.InvokeAsync<string[]>("devtoys.MonacoEditor.TextModel.deltaDecorations", Uri, oldDecorations, newDecorations, ownerId);
+        => runtime.InvokeAsync<string[]>("devtoys.MonacoEditor.TextModel.deltaDecorations", Uri, oldDecorations, newDecorations.PrepareJsInterop(), ownerId);
 
     /// <summary>
     /// Get the options associated with a decoration.

--- a/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditor.razor.cs
+++ b/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditor.razor.cs
@@ -77,13 +77,13 @@ public partial class MonacoEditor : RicherMonacoEditorBase
             options.MouseWheelZoom = false;
             options.OverviewRulerBorder = false;
             options.ScrollBeyondLastLine = false;
-            options.FontLigatures = false;
+            options.FontLigatures = true;
             options.SnippetSuggestions = "none";
             options.CodeLens = false;
             options.QuickSuggestions = new QuickSuggestionsOptions { Comments = false, Other = false, Strings = false };
             options.WordBasedSuggestions = false;
             options.Minimap = new EditorMinimapOptions { Enabled = false };
-            options.Hover = new EditorHoverOptions { Enabled = false };
+            options.Hover = new EditorHoverOptions { Enabled = true, Above = false };
             options.MatchBrackets = "always";
             options.BracketPairColorization = new BracketPairColorizationOptions { Enabled = true };
             options.RenderLineHighlightOnlyWhenFocus = true;

--- a/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditorDiff.razor.cs
+++ b/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditorDiff.razor.cs
@@ -51,12 +51,12 @@ public partial class MonacoEditorDiff : RicherMonacoEditorDiffBase
             options.MouseWheelZoom = false;
             options.OverviewRulerBorder = false;
             options.ScrollBeyondLastLine = false;
-            options.FontLigatures = false;
+            options.FontLigatures = true;
             options.SnippetSuggestions = "none";
             options.CodeLens = false;
             options.QuickSuggestions = new QuickSuggestionsOptions { Comments = false, Other = false, Strings = false };
             options.Minimap = new EditorMinimapOptions { Enabled = false };
-            options.Hover = new EditorHoverOptions { Enabled = false };
+            options.Hover = new EditorHoverOptions { Enabled = true, Above = false };
             options.MatchBrackets = "always";
             options.BracketPairColorization = new BracketPairColorizationOptions { Enabled = true };
             options.RenderLineHighlightOnlyWhenFocus = true;

--- a/src/app/dev/DevToys.Blazor/Core/Converters/PolymorphicConverter.cs
+++ b/src/app/dev/DevToys.Blazor/Core/Converters/PolymorphicConverter.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DevToys.Blazor.Core.Converters;
+
+internal sealed class PolymorphicConverter<T> : JsonConverter<T>
+{
+    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        Guard.IsNotNull(value);
+        JsonSerializer.Serialize(writer, value, value.GetType(), options);
+    }
+}

--- a/src/app/dev/DevToys.Blazor/Core/Converters/PolymorphicConverterFactory.cs
+++ b/src/app/dev/DevToys.Blazor/Core/Converters/PolymorphicConverterFactory.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DevToys.Blazor.Core.Converters;
+
+internal sealed class PolymorphicConverterFactory : JsonConverterFactory
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeToConvert.IsInterface || typeToConvert.IsAbstract;
+    }
+
+    /// <inheritdoc />
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        return (JsonConverter)Activator.CreateInstance(
+            typeof(PolymorphicConverter<>).MakeGenericType(typeToConvert),
+            BindingFlags.Instance | BindingFlags.Public,
+            null,
+            new object[] { },
+            null)!;
+    }
+}

--- a/src/app/dev/DevToys.Blazor/Core/Extensions/JsonExtensions.cs
+++ b/src/app/dev/DevToys.Blazor/Core/Extensions/JsonExtensions.cs
@@ -1,0 +1,113 @@
+﻿using System.Dynamic;
+using System.Text.Json;
+using DevToys.Blazor.Core.Converters;
+
+namespace DevToys.Blazor.Core.Extensions;
+
+internal static class JsonExtensions
+{
+    /// <summary>
+    /// Converts the given object to a dynamic object resulting from the serialization of the object using the given <paramref name="serializerOptions"/>.
+    /// By default, this method will not include null values. This can be beneficial for interop scenarios where a JavaScript code handles `undefined` and `null` differently.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// In Blazor, passing an object to a JavaScript using <see cref="IJSRuntime.InvokeAsync{TValue}(string, CancellationToken, object?[]?)"/> will serialize the object
+    /// into a JSON using a <see cref="JsonSerializerOptions"/> defined in the .NET framework.
+    /// <see href="https://github.com/dotnet/aspnetcore/blob/e6be3e95fec33ca3a3b576df4b265ead680a91a0/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs#L31-L44">See code on GitHub</see>.
+    /// Unfortunately, we are not allowed to customize this JSON serialization and can have a negative impact on us occasionally. For instance, it does not allow to exclude null values.
+    /// <see href="https://github.com/dotnet/aspnetcore/issues/12685">See issue #12685 on GitHub</see>
+    /// </para>
+    /// <para>
+    /// Monaco Editor, for instance, has many properties that are optional. Most of the time, it is fine. But occasionally, Monaco Editor behavior varies based on whether
+    /// a property is `null` or `undefined`.
+    /// </para>
+    /// <para>
+    /// This <see cref="PrepareJsInterop{T}(T, JsonSerializerOptions?)"/> method is workaround to this limitation as it will (by default) exclude null values from the JSON serialization,
+    /// making any .NET `null` value being interpreted as `undefined` in JavaScript.
+    /// </para>
+    /// <para>
+    /// Due to the nature of this method, it is recommended to avoid using this method as much as possible as it can cause some significant performance issues.
+    /// </para>
+    /// </remarks>
+    internal static object? PrepareJsInterop<T>(this T obj, JsonSerializerOptions? serializerOptions = null)
+    {
+        // Handle simple types
+        if (obj == null)
+        {
+            return obj;
+        }
+
+        Type type = obj.GetType();
+        if (obj.GetType().IsPrimitive || type == typeof(string))
+        {
+            return obj;
+        }
+
+        // Handle jsonElements
+        if (obj is JsonElement jsonElement)
+        {
+            return jsonElement.PrepareJsonElement();
+        }
+
+        // Set default serializer options if necessary
+        serializerOptions ??= new JsonSerializerOptions
+        {
+            MaxDepth = 32,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new PolymorphicConverterFactory()
+            }
+        };
+
+        // Handle all kind of complex objects
+        object? result
+            = JsonSerializer
+            .Deserialize<JsonElement>(
+                JsonSerializer.Serialize<object>(obj, serializerOptions))
+            .PrepareJsonElement();
+
+        return result;
+    }
+
+    private static object? PrepareJsonElement(this JsonElement obj)
+    {
+        switch (obj.ValueKind)
+        {
+            case JsonValueKind.Object:
+                IDictionary<string, object?> expando = new ExpandoObject();
+                foreach (JsonProperty property in obj.EnumerateObject())
+                {
+                    expando.Add(property.Name, property.Value.PrepareJsonElement());
+                }
+
+                return expando;
+
+            case JsonValueKind.Array:
+                return obj.EnumerateArray().Select(jsonElement => jsonElement.PrepareJsonElement());
+
+            case JsonValueKind.String:
+                return obj.GetString();
+
+            case JsonValueKind.Number:
+                return obj.GetDecimal();
+
+            case JsonValueKind.True:
+                return true;
+
+            case JsonValueKind.False:
+                return false;
+
+            case JsonValueKind.Null:
+                return null;
+
+            case JsonValueKind.Undefined:
+                return null;
+
+            default:
+                throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

In preparation of @btiteux work on `JWT Encoder / Decoder`, I was curious to demonstrate how to use `Monaco Editor` API to show some text on a given span when the mouse pass the mouse hover it. Like this:

![image](https://github.com/veler/DevToys/assets/3747805/9c1c5d9b-4021-4441-9a55-a5d9fd6ef28c)

Unfortunately, I quickly faced a bug where the JSON we pass from .NET code to JavaScript code has some properties that aren't expected by Monaco.

To add a message on hover of a span in Monaco, we need to create an instance of [MarkdownString](https://github.com/veler/DevToys/blob/769a0e8fcbd91c85397d557c48f060bb17748fa7/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/Monaco/MarkdownString.cs#L7-L18).
The minimum needed to make it work is to set a string to its `Value` property. However, that wasn't working.

The reason why is that when we send the `MarkdownString` to the JavaScript using `IJsRuntime.InvokeAsync`, we would get a JSON like this:

```json
{
    "value": "My text",
    "isTrusted": null,
    "supportThemeIcons": null,
    "supportHtml": null,
    "baseUri": null,
}
```

The problem is: in [these methods from Monaco](https://github.com/microsoft/vscode/blob/83b909c39f0ce5368d3a41a30c609de86a2e106e/src/vs/base/common/htmlContent.ts#L102-L121C2), it considers that this JSON isn't good if `supportThemeIcons` is null (instead of undefined, or with a boolean value).
As a consequence, the hover feature doesn't work.

## What is the new behavior?

As a fix, I created a method `PrepareJsInterop` that takes any object and convert it into a dynamic object, where null properties are excluded.

See the documentation on top of `PrepareJsInterop` to understand why I took this approach :-)

With this method invoked, the generated JSON is now:

```json
{
    "value": "My text"
}
```

## Other information

I considered some other approaches mentioned in https://github.com/dotnet/aspnetcore/issues/12685 but the best in my humble opinion was that `PrepareJsInterop` method.

In the future, once this PR is merged, creating a tooltip on hover in Monaco will be as simple as:

```csharp
TextModel model = await _monacoEditor.GetModelAsync();

if (model is not null)
{
    var decoration = new ModelDeltaDecoration
    {
        Range = new Monaco.Range
        {
            StartLineNumber = 1,
            StartColumn = 1,
            EndLineNumber = 1,
            EndColumn = 10
        },
        Options = new ModelDecorationOptions
        {
            HoverMessage
                = new[]
                {
                    new MarkdownString()
                    {
                        Value = "hello world !"
                    }
                }
        }
    };

    await _monacoEditor.ReplaceAllDecorationsByAsync(new [] { decorations });
}
```

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [X] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [X] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)