### PR TITLE
Fixed bug: Smart detection when dialog opened

### DIFF
--- a/src/app/dev/DevToys.Blazor/Pages/Index.razor.cs
+++ b/src/app/dev/DevToys.Blazor/Pages/Index.razor.cs
@@ -89,7 +89,7 @@ public partial class Index : MefComponentBase
         StateHasChanged();
 
         // Start Smart Detection
-        ViewModel.RunSmartDetectionAsync(WindowService.IsCompactOverlayMode)
+        ViewModel.RunSmartDetectionAsync(WindowService.IsCompactOverlayMode, DialogService.IsDialogOpened)
             .ContinueWith(async _ =>
             {
                 await InvokeAsync(StateHasChanged);
@@ -161,7 +161,7 @@ public partial class Index : MefComponentBase
             _navBar.TryFocusSearchBoxAsync();
 
             // Start Smart Detection
-            ViewModel.RunSmartDetectionAsync(WindowService.IsCompactOverlayMode).Forget();
+            ViewModel.RunSmartDetectionAsync(WindowService.IsCompactOverlayMode, DialogService.IsDialogOpened).Forget();
         }
 
         if (IsTransitioning)

--- a/src/app/dev/DevToys.Business/ViewModels/MainWindowViewModel.cs
+++ b/src/app/dev/DevToys.Business/ViewModels/MainWindowViewModel.cs
@@ -204,9 +204,11 @@ internal sealed partial class MainWindowViewModel : ObservableRecipient
     /// <summary>
     /// Get the data from the clipboard and try to detect tools that can accept the clipboard data as an input.
     /// </summary>
-    internal async Task RunSmartDetectionAsync(bool isInCompactOverlayMode)
+    internal async Task RunSmartDetectionAsync(bool isInCompactOverlayMode, bool isDialogOpened)
     {
-        if (isInCompactOverlayMode || !_settingsProvider.GetSetting(PredefinedSettings.SmartDetection))
+        if (isInCompactOverlayMode
+            || isDialogOpened
+            || !_settingsProvider.GetSetting(PredefinedSettings.SmartDetection))
         {
             return;
         }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

1. Go to Extension Manager
2. Click "Install". A dialog asking to click "I understand" opens.
3. Go in VS Code or web browser: Copy a Markdown code
4. Go back to DevToys.

DevToys will switch to the Markdown Preview tool because of Smart Detection. The dialog will still be opened but will be empty (no content inside). User is trapped. No way to close the dialog.

## What is the new behavior?

We do not run Smart Detection while a dialog is opened.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [X] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)