### PR TITLE
Window position and size is now saved and restore when reopening the app

### DIFF
--- a/src/app/dev/DevToys.Api/Settings/SettingDefinition.cs
+++ b/src/app/dev/DevToys.Api/Settings/SettingDefinition.cs
@@ -18,6 +18,16 @@ public readonly struct SettingDefinition<T> : IEquatable<SettingDefinition<T>>
     public T DefaultValue { get; }
 
     /// <summary>
+    /// Gets a callback that can be used to serialize the value of the setting.
+    /// </summary>
+    public Func<T, string>? Serialize { get; }
+
+    /// <summary>
+    /// Gets a callback that can be used to deserialize the value of the setting.
+    /// </summary>
+    public Func<string, T>? Deserialize { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="SettingDefinition{T}"/> structure.
     /// </summary>
     /// <param name="name">The name of the setting. Should be unique.</param>
@@ -40,6 +50,22 @@ public readonly struct SettingDefinition<T> : IEquatable<SettingDefinition<T>>
 
         Name = name;
         DefaultValue = defaultValue;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SettingDefinition{T}"/> structure.
+    /// </summary>
+    /// <param name="name">The name of the setting. Should be unique.</param>
+    /// <param name="defaultValue">The default value of the setting.</param>
+    /// <param name="serialize">A callback that can be used to serialize the value of the setting.</param>
+    /// <param name="deserialize">A callback that can be used to deserialize the value of the setting.</param>
+    public SettingDefinition(string name, T defaultValue, Func<T, string> serialize, Func<string, T> deserialize)
+        : this(name, defaultValue)
+    {
+        Guard.IsNotNull(serialize);
+        Guard.IsNotNull(deserialize);
+        Serialize = serialize;
+        Deserialize = deserialize;
     }
 
     /// <summary>

--- a/src/app/dev/DevToys.Core/Settings/PredefinedSettings.cs
+++ b/src/app/dev/DevToys.Core/Settings/PredefinedSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace DevToys.Core.Settings;
+﻿using SixLabors.ImageSharp;
+
+namespace DevToys.Core.Settings;
 
 public static class PredefinedSettings
 {
@@ -154,4 +156,53 @@ public static class PredefinedSettings
         = new(
             name: nameof(TextEditorPasteClearsText),
             defaultValue: true);
+
+    /// <summary>
+    /// The size and position of the main window.
+    /// </summary>
+    public static readonly SettingDefinition<Rectangle?> MainWindowBounds
+        = new(
+            name: nameof(MainWindowBounds),
+            defaultValue: null,
+            serialize: SerializeRectangle,
+            deserialize: DeserializeRectangle);
+
+    /// <summary>
+    /// Whether the main window should be maximized.
+    /// </summary>
+    public static readonly SettingDefinition<bool> MainWindowMaximized
+        = new(
+            name: nameof(MainWindowMaximized),
+            defaultValue: false);
+
+    internal static string SerializeRectangle(Rectangle? rectangle)
+    {
+        if (rectangle is null)
+        {
+            return string.Empty;
+        }
+
+        return $"{rectangle.Value.X},{rectangle.Value.Y},{rectangle.Value.Width},{rectangle.Value.Height}";
+    }
+
+    internal static Rectangle? DeserializeRectangle(string serializedRectangle)
+    {
+        if (string.IsNullOrEmpty(serializedRectangle))
+        {
+            return null;
+        }
+
+        string[] parts = serializedRectangle.Split(',');
+        if (parts.Length != 4)
+        {
+            throw new ArgumentException("Invalid serialized rectangle format.");
+        }
+
+        int x = int.Parse(parts[0]);
+        int y = int.Parse(parts[1]);
+        int width = int.Parse(parts[2]);
+        int height = int.Parse(parts[3]);
+
+        return new Rectangle(x, y, width, height);
+    }
 }

--- a/src/app/dev/DevToys.Core/Settings/SettingsProvider.cs
+++ b/src/app/dev/DevToys.Core/Settings/SettingsProvider.cs
@@ -24,7 +24,11 @@ internal sealed partial class SettingsProvider : ISettingsProvider
     {
         if (_settingsStorage.TryReadSetting(settingDefinition.Name, out object? settingValue))
         {
-            if (typeof(T).IsEnum)
+            if (settingDefinition.Deserialize is not null)
+            {
+                return settingDefinition.Deserialize(settingValue?.ToString() ?? string.Empty);
+            }
+            else if (typeof(T).IsEnum)
             {
                 return (T)Enum.Parse(typeof(T), settingValue?.ToString() ?? string.Empty);
             }
@@ -60,7 +64,12 @@ internal sealed partial class SettingsProvider : ISettingsProvider
     public void SetSetting<T>(SettingDefinition<T> settingDefinition, T value)
     {
         object? valueToSave = value;
-        if (value is Enum valueEnum)
+
+        if (settingDefinition.Serialize is not null)
+        {
+            valueToSave = settingDefinition.Serialize(value);
+        }
+        else if (value is Enum valueEnum)
         {
             valueToSave = valueEnum.ToString();
         }

--- a/src/app/dev/platforms/desktop/DevToys.MacOS/AppDelegate.cs
+++ b/src/app/dev/platforms/desktop/DevToys.MacOS/AppDelegate.cs
@@ -93,7 +93,7 @@ public class AppDelegate : NSApplicationDelegate
         NSApplication.SharedApplication.MainMenu = new AppMenuBar();
 
         // Show the main window
-        MainWindow.Instance.Show();
+        MainWindow.Instance.ShowAsync().Forget();
     }
 
     public override bool ApplicationShouldTerminateAfterLastWindowClosed(NSApplication sender)

--- a/src/app/dev/platforms/desktop/DevToys.MacOS/Core/WindowService.cs
+++ b/src/app/dev/platforms/desktop/DevToys.MacOS/Core/WindowService.cs
@@ -70,14 +70,6 @@ internal sealed class WindowService : IWindowService
     private void OnWindowClosing(object? sender, EventArgs e)
     {
         WindowClosing?.Invoke(this, EventArgs.Empty);
-
-        Guard.IsNotNull(AppDelegate.MefComposer);
-
-        // Dispose every disposable tool instance.
-        AppDelegate.MefComposer.Provider.Import<GuiToolProvider>().DisposeTools();
-
-        // Clear older temp files.
-        FileHelper.ClearTempFiles(Constants.AppTempFolder);
     }
 
     private void UpdateCompactOverlayState(bool shouldEnterCompactOverlayMode)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

DevToys 2.0's window's size and position weren't saved and restore after closing/starting the app.

## What is the new behavior?

We now do it on Windows and MacOS.
We won't do it on Linux because GTK 4 doesn't have an API to move and resize a window (same reason why we don't support Picture-in-Picture)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [X] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [X] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)