### PR TITLE
Enable NuGet Transitive Pinning

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,6 +33,7 @@
 
     <!-- Enable Central Package Management -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
 
     <!-- Keep generated code in `obj` folder -->


### PR DESCRIPTION
This enables [Transitive Pinning](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management#transitive-pinning) which essentially makes your `Directory.Packages.props` a partial lock file. If a package is listed in `Directory.Packages.props`, that will be the version, even if a project doesn't explicitly reference that package and it's just a transitive dependency. This is the primary benefit of transitive pinning, to ensure all projects within the repo are using the same version of all packages. It also allows security issues in transitive dependencies to be more easily addressed by simply updating `Directory.Packages.props` instead of adding a top-level dependency to all impacted projects, which is far messier and less maintainable.